### PR TITLE
infinite pk respawn glitch

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
@@ -231,7 +231,7 @@ public class PacketListener implements Listener
                                 @Override
                                 public void run()
                                 {
-                                    infinite.respawn();
+                                    if (playerStats.isInInfinite()) infinite.respawn(); // conditional to avoid glitched tping on roof
                                 }
                             }.runTask(Momentum.getPlugin());
                         }


### PR DESCRIPTION
possible fix of the respawn glitch when respawning and infinite pk ending happens in the wrong order