### PR TITLE
Resolve x and z bug with cp

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointManager.java
@@ -125,7 +125,7 @@ public class CheckpointManager {
 
             if (
                 loc.getWorld().getName().equalsIgnoreCase(playerStats.getPlayer().getWorld().getName()) &&
-                playerStats.getPlayer().getLocation().distance(loc) > 1.0 && !playerStats.inPracticeMode()
+                !Utils.isNearby(playerStats.getPlayer().getLocation(), loc, 1.0) && !playerStats.inPracticeMode()
                ) // only add a fail when no practice
                 playerStats.addFail();
 
@@ -142,7 +142,7 @@ public class CheckpointManager {
 
             if (
                 loc.getWorld().getName().equalsIgnoreCase(playerStats.getPlayer().getWorld().getName()) &&
-                playerStats.getPlayer().getLocation().distance(loc) > 1.0
+                !Utils.isNearby(playerStats.getPlayer().getLocation(), loc, 1.0)
                )
                 playerStats.addFail();
 

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
@@ -2,6 +2,7 @@ package com.renatusnetwork.momentum.data.levels;
 
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
+import com.renatusnetwork.momentum.utils.Utils;
 import org.bukkit.Location;
 
 public class LevelPreview
@@ -24,7 +25,9 @@ public class LevelPreview
 
     public boolean shouldTeleport(Location current)
     {
-        return level.getStartLocation().distance(current) > Momentum.getSettingsManager().preview_max_distance;
+        float distance = Momentum.getSettingsManager().preview_max_distance;
+
+        return !Utils.isNearby(level.getStartLocation(), current, distance);
     }
 
     public void teleport()

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
@@ -550,7 +550,7 @@ public class MenuItemFormatter
                 // show they need to buy it and it is not the jackpot level if it is running
                 if (!(bankManager.isJackpotRunning() &&
                         bankManager.getJackpot().getLevel().equals(level)) &&
-                        level.requiresBuying() && !playerStats.hasBoughtLevel(level) && !playerStats.hasCompleted(level))
+                        level.requiresBuying() && !playerStats.hasBoughtLevel(level) && !playerStats.hasCompleted(level) && !level.isFeaturedLevel())
                 {
 
                     int price = level.getPrice();

--- a/src/main/java/com/renatusnetwork/momentum/data/saves/SavesManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/saves/SavesManager.java
@@ -75,8 +75,9 @@ public class SavesManager
 
         return playerStats.inLevel() &&
                 (
-                    (playerStats.hasCurrentCheckpoint() && playerStats.getCurrentCheckpoint().distance(player.getLocation()) <= 1.0) ||
-                    playerStats.getLevel().getStartLocation().distance(player.getLocation()) <= 1.0
+                    (playerStats.hasCurrentCheckpoint() &&
+                    Utils.isNearby(playerStats.getCurrentCheckpoint(), player.getLocation(), 1.0)) ||
+                    Utils.isNearby(playerStats.getLevel().getStartLocation(), player.getLocation(), 1.0)
                 );
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/LevelListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/LevelListener.java
@@ -117,25 +117,16 @@ public class LevelListener implements Listener {
 
                 // gold plate = checkpoint
                 if (
-                        playerStats != null &&
-                        playerStats.isLoaded() &&
-                        playerStats.inLevel() &&
-                        !playerStats.inPracticeMode() &&
-                        !playerStats.isSpectating() &&
-                        !playerStats.isAttemptingMastery() &&
-                        !playerStats.isPreviewingLevel())
-                {
-                    if (playerStats.hasCurrentCheckpoint())
-                    {
-                        int blockX = playerStats.getCurrentCheckpoint().getBlockX();
-                        int blockZ = playerStats.getCurrentCheckpoint().getBlockZ();
-
-                        if (!(blockX == block.getLocation().getBlockX() && blockZ == block.getLocation().getBlockZ()))
-                            setCheckpoint(playerStats, block.getLocation());
-                    }
-                    else
-                        setCheckpoint(playerStats, block.getLocation());
-                }
+                    playerStats != null &&
+                    playerStats.isLoaded() &&
+                    playerStats.inLevel() &&
+                    !playerStats.inPracticeMode() &&
+                    !playerStats.isSpectating() &&
+                    !playerStats.isAttemptingMastery() &&
+                    !playerStats.isPreviewingLevel() &&
+                    (!playerStats.hasCurrentCheckpoint() || !Utils.isNearby(block.getLocation(), playerStats.getCurrentCheckpoint(), 1.5))
+                )
+                    setCheckpoint(playerStats, block.getLocation());
             }
             else if (block.getType() == Material.IRON_PLATE)
             {

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
@@ -192,7 +192,7 @@ public class PacketListener implements Listener
                         {
 
                             if (!beingSpectated.getPlayer().getWorld().getName().equalsIgnoreCase(playerStats.getPlayer().getWorld().getName()) ||
-                                    playerStats.getPlayer().getLocation().distance(beingSpectated.getPlayer().getLocation()) > 30)
+                                !Utils.isNearby(playerStats.getPlayer().getLocation(), beingSpectated.getPlayer().getLocation(), 30.0))
 
                                 // run in sync due to teleporting
                                 new BukkitRunnable()

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -462,4 +462,9 @@ public class Utils {
 
         return yaw;
     }
+
+    public static boolean isNearby(Location from, Location to, double distance)
+    {
+        return from.distanceSquared(to) <= (distance * distance);
+    }
 }


### PR DESCRIPTION
fixes the problem where checkpoints on same x and z (but above or below in y) did not set the cp. Fixed that and made a new Utils.isNearby method to micro optimize .distance to .distanceSquared with a easy to use helper method. Also fixed a very minor bug where the featured level showed buying details + shift click to preview, featured level are free if the player hasnt bought it.