### PR TITLE
sponge boosting exploit bugfix

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/data/blackmarket/BlackMarketManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/blackmarket/BlackMarketManager.java
@@ -207,7 +207,7 @@ public class BlackMarketManager
                 for (PlayerStats playerStats : running.getPlayers())
                 {
                     Player player = playerStats.getPlayer();
-                    player.teleport(Momentum.getLocationManager().getSpawnLocation()); // teleport to spawn
+                    playerStats.teleport(Momentum.getLocationManager().getSpawnLocation(), false); // teleport to spawn
 
                     if (running.hasHighestBidder())
                     {
@@ -275,7 +275,7 @@ public class BlackMarketManager
                 running.addPlayer(playerStats);
                 player.playSound(player.getLocation(), Sound.BLOCK_PORTAL_AMBIENT, 1.0F, 1.0F); // play noise
                 playerStats.sendTitle("&8&lBlack Market", "&7We will be starting soon...", 20, 100, 20); // send title
-                playerStats.getPlayer().teleport(Momentum.getLocationManager().get(Momentum.getSettingsManager().blackmarket_tp_loc));
+                playerStats.teleport(Momentum.getLocationManager().get(Momentum.getSettingsManager().blackmarket_tp_loc), true);
                 playerStats.setBlackMarket(true);
             }
         }
@@ -313,7 +313,7 @@ public class BlackMarketManager
             running.end(true);
 
             for (PlayerStats playerStats : running.getPlayers())
-                playerStats.getPlayer().teleport(Momentum.getLocationManager().getSpawnLocation()); // teleport to spawn
+                playerStats.teleport(Momentum.getLocationManager().getSpawnLocation(), false); // teleport to spawn
         }
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointManager.java
@@ -129,7 +129,7 @@ public class CheckpointManager {
                ) // only add a fail when no practice
                 playerStats.addFail();
 
-            playerStats.teleport(loc, false);
+            playerStats.teleport(loc, true);
 
         // if the level has a stored start loc (not spawn), tp them to it
         }
@@ -146,7 +146,7 @@ public class CheckpointManager {
                )
                 playerStats.addFail();
 
-            playerStats.teleport(loc, false);
+            playerStats.teleport(loc, true);
         }
         else
             playerStats.sendMessage(Utils.translate("&cNo location loaded to teleport you to"));

--- a/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
@@ -248,7 +248,7 @@ public class EventManager {
         else if (isMazeEvent())
             ((MazeEvent) runningEvent).respawn(player);
         else
-            player.teleport(runningEvent.getLevel().getStartLocation());
+            playerStats.teleport(runningEvent.getLevel().getStartLocation(), true);
 
         // remove active effects
         playerStats.clearPotionEffects();
@@ -291,7 +291,7 @@ public class EventManager {
         }
 
         playerStats.leftEvent();
-        player.teleport(eventParticipant.getOriginalLocation());
+        playerStats.teleport(eventParticipant.getOriginalLocation(), true);
         player.setHealth(20.0);
 
         if (isAscentEvent())

--- a/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
@@ -53,13 +53,13 @@ public abstract class Infinite
         tpLoc.setPitch(getPlayer().getLocation().getPitch());
         tpLoc.setYaw(getPlayer().getLocation().getYaw());
 
-        getPlayer().teleport(tpLoc.add(0.5, 1, 0.5));
+        playerStats.teleport(tpLoc.add(0.5, 1, 0.5), true);
     }
 
     public void end()
     {
         playerStats.setInfinite(false);
-        getPlayer().teleport(getOriginalLoc()); // tp back
+        playerStats.teleport(getOriginalLoc(), true); // tp back
         clearBlocks();
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -1188,7 +1188,7 @@ public class LevelManager
 
                 setLevelInfoOnTeleport(opponentStats, opponent.getOriginalLocation());
                 opponentStats.disableLevelStartTime();
-                opponentStats.teleport(opponent.getOriginalLocation(), false);
+                opponentStats.teleport(opponent.getOriginalLocation(), true);
 
                 playerStats.endRace(race, RaceEndReason.WON);
             }
@@ -1212,7 +1212,7 @@ public class LevelManager
             setLevelInfoOnTeleport(playerStats, locationTo);
 
             // teleport
-            player.teleport(locationTo);
+            playerStats.teleport(locationTo, true);
 
             LevelLBPosition recordCompletion = level.getRecordCompletion();
 
@@ -1277,7 +1277,7 @@ public class LevelManager
 
             if (loc != null)
             {
-                playerStats.getPlayer().teleport(loc);
+                playerStats.teleport(loc, true);
                 playerStats.addFail(); // used in multiple areas
             }
         }

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
@@ -32,11 +32,11 @@ public class LevelPreview
 
     public void teleport()
     {
-        playerStats.getPlayer().teleport(level.getStartLocation());
+        playerStats.teleport(level.getStartLocation(), false);
     }
 
     public void reset()
     {
-        playerStats.getPlayer().teleport(oldLocation);
+        playerStats.teleport(oldLocation, true);
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/locations/LocationManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/locations/LocationManager.java
@@ -239,7 +239,7 @@ public class LocationManager {
         }
 
         Momentum.getStatsManager().leaveLevelAndReset(playerStats, true);
-        player.teleport(loc);
+        playerStats.teleport(loc, true);
     }
 
     public boolean equals(Location one, Location two)

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemAction.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemAction.java
@@ -168,7 +168,7 @@ public class MenuItemAction {
                 playerStats.getPlayer().closeInventory();
 
                 playerStats.setPracticeCheckpoint(location, false);
-                playerStats.teleport(location, false);
+                playerStats.teleport(location, true);
             }
         }
     }
@@ -733,7 +733,7 @@ public class MenuItemAction {
                     tpToStart = true;
 
                 if (tpToStart) {
-                    player.teleport(level.getStartLocation());
+                    playerStats.teleport(level.getStartLocation(), true);
 
                     player.sendMessage(Utils.translate("&7You were teleported to the start of " + level.getTitle()));
 

--- a/src/main/java/com/renatusnetwork/momentum/data/plots/PlotsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/plots/PlotsManager.java
@@ -129,7 +129,7 @@ public class PlotsManager {
         // set bedrock -1 where they teleport
         creationLoc.clone().subtract(0, 1, 0).getBlock().setType(Material.BEDROCK);
 
-        player.teleport(creationLoc.clone().add(0.5, 0, 0.5));
+        playerStats.teleport(creationLoc.clone().add(0.5, 0, 0.5), false);
 
         // generate next free plot location
         loadNextFreePlot(creationLoc);

--- a/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
@@ -131,7 +131,7 @@ public class RacePlayer
 
     public void resetLevelAndTeleport()
     {
-        playerStats.teleport(originalLocation, false);
+        playerStats.teleport(originalLocation, true);
         Momentum.getLevelManager().setLevelInfoOnTeleport(playerStats, originalLocation);
     }
 
@@ -166,7 +166,7 @@ public class RacePlayer
         Location raceLoc = location.clone();
         raceLoc.setYaw(player.getLocation().getYaw());
         raceLoc.setPitch(player.getLocation().getPitch());
-        player.teleport(raceLoc);
+        playerStats.teleport(raceLoc, true);
     }
 
     public PlayerStats getPlayerStats()

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -851,7 +851,7 @@ public class StatsManager {
     {
         Player player = playerStats.getPlayer();
 
-        player.teleport(playerStats.getPracticeStart());
+        playerStats.teleport(playerStats.getPracticeStart(), true);
         resetPracticeDataOnly(playerStats);
 
         if (message)
@@ -886,7 +886,7 @@ public class StatsManager {
 
         if (player.isOnline() && spectator.isOnline())
         {
-            spectator.teleport(player.getLocation());
+            spectatorStats.teleport(player.getLocation(), false);
 
             // this is done AFTER teleport to override some world changes that can happen
             if (initialSpectate)
@@ -932,7 +932,7 @@ public class StatsManager {
 
         if (loc != null)
         {
-            player.teleport(loc);
+            spectatorStats.teleport(loc, true);
             spectatorStats.sendTitle("", "&7You are no longer spectating anyone", 10, 40, 10);
             spectatorStats.resetSpectateSpawn();
 

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -123,7 +123,7 @@ public class InteractListener implements Listener {
                                                 }
                                                 resetConfirmMap.remove(player.getName());
 
-                                                player.teleport(level.getStartLocation());
+                                                playerStats.teleport(level.getStartLocation(), true);
                                                 playerStats.resetFails();
                                                 player.playSound(player.getLocation(), Sound.BLOCK_WOODEN_DOOR_CLOSE, 0.5f, 1f);
                                             }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/JoinLeaveListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/JoinLeaveListener.java
@@ -180,7 +180,7 @@ public class JoinLeaveListener implements Listener
         {
             // if in dropper, respawn them
             if (playerStats.getLevel().isDropper())
-                player.teleport(playerStats.getLevel().getStartLocation());
+                playerStats.teleport(playerStats.getLevel().getStartLocation(), true);
 
             // run reset logic
             playerStats.resetLevel();

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/LevelListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/LevelListener.java
@@ -267,7 +267,7 @@ public class LevelListener implements Listener {
                             }
 
                             Momentum.getStatsManager().leaveLevelAndReset(playerStats, true);
-                            player.teleport(lobby);
+                            playerStats.teleport(lobby, true);
                         }
                     }
                 }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/MenuListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/MenuListener.java
@@ -92,7 +92,7 @@ public class MenuListener implements Listener
                                     plotSpawn.setPitch(player.getLocation().getPitch());
                                     plotSpawn.setYaw(player.getLocation().getYaw());
 
-                                    player.teleport(plotSpawn);
+                                    playerStats.teleport(plotSpawn, true);
                                     player.sendMessage(Utils.translate("&cYou teleported to &4" + plot.getOwnerName() + "&c's Plot"));
                                 } else {
                                     player.sendMessage(Utils.translate("&cPlot does not exist"));


### PR DESCRIPTION
exploit where players get boosted from sponge after tping (either using /prac, checkpoint, /spawn, or some other means of teleporting) with right timing fixed

also changed, where applicable, all instances of entity#teleport to use playerstats#teleport