### PR TITLE
slowness when ending event/race

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
@@ -292,6 +292,7 @@ public class EventManager {
 
         playerStats.leftEvent();
         playerStats.teleport(eventParticipant.getOriginalLocation(), true);
+        Utils.applySlowness(player, 255, 20);
         player.setHealth(20.0);
 
         if (isAscentEvent())

--- a/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/events/EventManager.java
@@ -292,7 +292,7 @@ public class EventManager {
 
         playerStats.leftEvent();
         playerStats.teleport(eventParticipant.getOriginalLocation(), true);
-        Utils.applySlowness(player, 255, 20);
+        Utils.applySlowness(player);
         player.setHealth(20.0);
 
         if (isAscentEvent())

--- a/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
@@ -61,7 +61,7 @@ public abstract class Infinite
     {
         playerStats.setInfinite(false);
         playerStats.teleport(getOriginalLoc(), true); // tp back
-        Utils.applySlowness(getPlayer(), 255, 20);
+        Utils.applySlowness(getPlayer());
         clearBlocks();
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/infinite/gamemode/Infinite.java
@@ -2,6 +2,7 @@ package com.renatusnetwork.momentum.data.infinite.gamemode;
 
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
+import com.renatusnetwork.momentum.utils.Utils;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -60,6 +61,7 @@ public abstract class Infinite
     {
         playerStats.setInfinite(false);
         playerStats.teleport(getOriginalLoc(), true); // tp back
+        Utils.applySlowness(getPlayer(), 255, 20);
         clearBlocks();
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
@@ -132,6 +132,7 @@ public class RacePlayer
     public void resetLevelAndTeleport()
     {
         playerStats.teleport(originalLocation, true);
+        Utils.applySlowness(playerStats.getPlayer(), 255, 20);
         Momentum.getLevelManager().setLevelInfoOnTeleport(playerStats, originalLocation);
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/races/gamemode/RacePlayer.java
@@ -132,7 +132,7 @@ public class RacePlayer
     public void resetLevelAndTeleport()
     {
         playerStats.teleport(originalLocation, true);
-        Utils.applySlowness(playerStats.getPlayer(), 255, 20);
+        Utils.applySlowness(playerStats.getPlayer());
         Momentum.getLevelManager().setLevelInfoOnTeleport(playerStats, originalLocation);
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -934,7 +934,7 @@ public class StatsManager {
         {
             spectatorStats.teleport(loc, true);
             spectatorStats.sendTitle("", "&7You are no longer spectating anyone", 10, 40, 10);
-            Utils.applySlowness(spectatorStats.getPlayer(), 255, 1);
+            Utils.applySlowness(spectatorStats.getPlayer(), 255, 20);
             spectatorStats.resetSpectateSpawn();
 
             Momentum.getLevelManager().regionLevelCheck(spectatorStats, loc);

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -934,7 +934,7 @@ public class StatsManager {
         {
             spectatorStats.teleport(loc, true);
             spectatorStats.sendTitle("", "&7You are no longer spectating anyone", 10, 40, 10);
-            Utils.applySlowness(spectatorStats.getPlayer(), 255, 20);
+            Utils.applySlowness(spectatorStats.getPlayer());
             spectatorStats.resetSpectateSpawn();
 
             Momentum.getLevelManager().regionLevelCheck(spectatorStats, loc);

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -934,6 +934,7 @@ public class StatsManager {
         {
             spectatorStats.teleport(loc, true);
             spectatorStats.sendTitle("", "&7You are no longer spectating anyone", 10, 40, 10);
+            Utils.applySlowness(spectatorStats.getPlayer(), 255, 1);
             spectatorStats.resetSpectateSpawn();
 
             Momentum.getLevelManager().regionLevelCheck(spectatorStats, loc);

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import java.text.DecimalFormat;
 import java.util.*;
@@ -466,5 +467,9 @@ public class Utils {
     public static boolean isNearby(Location from, Location to, double distance)
     {
         return from.distanceSquared(to) <= (distance * distance);
+    }
+
+    public static void applySlowness(Player player, int amplifier, int duration /* in ticks */) {
+        player.addPotionEffect(PotionEffectType.SLOW.createEffect(duration, amplifier));
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -2,7 +2,6 @@ package com.renatusnetwork.momentum.utils;
 
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.data.SettingsManager;
-import com.renatusnetwork.momentum.data.blackmarket.BlackMarketManager;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
 import com.renatusnetwork.momentum.data.stats.StatsManager;
 import net.md_5.bungee.api.chat.ClickEvent;
@@ -469,7 +468,7 @@ public class Utils {
         return from.distanceSquared(to) <= (distance * distance);
     }
 
-    public static void applySlowness(Player player, int amplifier, int duration /* in ticks */) {
-        player.addPotionEffect(PotionEffectType.SLOW.createEffect(duration, amplifier));
+    public static void applySlowness(Player player   /* in ticks */) {
+        player.addPotionEffect(PotionEffectType.SLOW.createEffect(20, 255));
     }
 }


### PR DESCRIPTION
slowness is applied to the player when they get tped back to their original location when ending an event/race or unspectating a player