### PR TITLE
Command Signs Tweaks

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -114,7 +114,7 @@ public class CommandSignCMD implements CommandExecutor {
                 }
 
                 result = csignManager.updateCommand(name, index, cmd);
-                sender.sendMessage(result ? Utils.translate("&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cIndex &4" + (index + 1) + " &cdoes not exist for &4" + name));
+                sender.sendMessage(Utils.translate(result ? "&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name : Utils.translate("&cIndex &4" + (index + 1) + " &cdoes not exist for &4" + name)));
                 break;
             case "broadcast":
                 if (!csignManager.commandSignExists(name)) {
@@ -188,7 +188,7 @@ public class CommandSignCMD implements CommandExecutor {
                 }
 
                 result = csignManager.removeCommand(name, index);
-                sender.sendMessage(result ? Utils.translate("&aSuccessfully removed command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name));
+                sender.sendMessage(Utils.translate(result ? "&aSuccessfully removed command at index &2" + (index + 1) + " &afor &2" + name : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name)));
                 break;
             default:
                 sendHelp(sender);

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -163,6 +163,12 @@ public class CommandSignCMD implements CommandExecutor {
                     return true;
                 }
 
+                if (a[2].equalsIgnoreCase("all")) {
+                    csignManager.clearCommands(name);
+                    sender.sendMessage(Utils.translate("&aSuccessfully removed all commands for &2" + name));
+                    break;
+                }
+
                 try {
                     index = Integer.parseInt(a[2]) - 1; // minus one since the displayed list in game is shifted to start at 1 instead of 0 for practicality
                 } catch (NumberFormatException ignore) {
@@ -191,7 +197,7 @@ public class CommandSignCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/commandsign delete <name> &7Deletes the specified command sign"));
         sender.sendMessage(Utils.translate("&a/commandsign modify <name> <index> <command>  &7Updates a sign's command at the specified index"));
         sender.sendMessage(Utils.translate("&a/commandsign add <name> <command>  &7Adds a command to the command sign"));
-        sender.sendMessage(Utils.translate("&a/commandsign remove <name> <index>  &7Removes the command at the specified index from the command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign remove <name> <index|all>  &7Removes the command at the specified index, or all commands, from the command sign"));
         sender.sendMessage(Utils.translate("&a/commandsign broadcast <name>  &7Toggles broadcast on a sign"));
         sender.sendMessage(Utils.translate("&a/commandsign title <name> <title>  &7Sets sign title"));
     }

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -39,71 +39,143 @@ public class CommandSignCMD implements CommandExecutor {
         CommandSignManager csignManager = Momentum.getCommandSignManager();
         String name = a[1];
 
-        if (a[0].equalsIgnoreCase("create")) {
-            if (!(sender instanceof Player)) {
-                sender.sendMessage(Utils.translate("&cConsole cannot run this"));
-                return true;
-            }
-            if (a.length < 5) {
+        // switch variable stuff
+        int index;
+        String cmd;
+        boolean result;
+        switch (a[0].toLowerCase()) {
+            case "create":
+                if (!(sender instanceof Player)) {
+                    sender.sendMessage(Utils.translate("&cConsole cannot run this"));
+                    return true;
+                }
+                if (a.length < 5) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                Player player = (Player) sender;
+
+                int x, y, z;
+                try {
+                    x = Integer.parseInt(a[2]);
+                    y = Integer.parseInt(a[3]);
+                    z = Integer.parseInt(a[4]);
+                } catch (NumberFormatException ignore) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                if (csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cCommand sign already exists with that name"));
+                } else if (csignManager.commandSignExists(new CmdSignLocation(player.getWorld(), x, y, z))) {
+                    sender.sendMessage(Utils.translate("&cCommand sign already exists at that location"));
+                } else {
+                    cmd = String.join(" ", Arrays.copyOfRange(a, 5, a.length));
+                    csignManager.addCommandSign(name, cmd.isEmpty() ? null : cmd, player.getWorld(), x, y, z);
+                    sender.sendMessage(Utils.translate("&aSuccessfully created command sign at (" + x + ", " + y + ", " + z + ")"));
+                }
+                break;
+            case "delete":
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cCommand sign does not exist with that name"));
+                } else {
+                    csignManager.deleteCommandSign(name);
+                    sender.sendMessage(Utils.translate("&aSuccessfully deleted command sign &2" + name));
+                }
+                break;
+            case "modify":
+                if (a.length < 3) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+
+                try {
+                    index = Integer.parseInt(a[2]) - 1; // minus one since the displayed list in game is shifted to start at 1 instead of 0 for practicality
+                } catch (NumberFormatException ignore) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                cmd = String.join(" ", Arrays.copyOfRange(a, 3, a.length));
+                if (cmd.isEmpty()) {
+                    sendHelp(sender);
+                    return true;
+                }
+                result = csignManager.updateCommand(name, index, cmd);
+                sender.sendMessage(result ? Utils.translate("&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name));
+                break;
+            case "broadcast":
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+                csignManager.toggleBroadcast(name);
+                sender.sendMessage(Utils.translate("&7Toggled broadcast of &a" + name + "&7 to " + (csignManager.getCommandSign(name).isBroadcast() ? "&atrue" : "&cfalse")));
+                break;
+            case "title":
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+
+                String title = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
+                csignManager.updateTitle(name, title);
+                sender.sendMessage(Utils.translate("&7Set title for &2" + name + "&7 to &a" + title));
+                break;
+            case "show":
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+
+                CommandSign csign = csignManager.getCommandSign(name);
+                showInfo(sender, csign);
+                break;
+            case "add":
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+
+                cmd = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
+                if (cmd.isEmpty()) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                csignManager.addCommand(name, cmd);
+                sender.sendMessage(Utils.translate("&aSuccessfully added command to &2" + name));
+                break;
+            case "remove":
+                if (a.length < 3) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                if (!csignManager.commandSignExists(name)) {
+                    sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
+                    return true;
+                }
+
+                try {
+                    index = Integer.parseInt(a[2]) - 1; // minus one since the displayed list in game is shifted to start at 1 instead of 0 for practicality
+                } catch (NumberFormatException ignore) {
+                    sendHelp(sender);
+                    return true;
+                }
+
+                result = csignManager.removeCommand(name, index);
+                sender.sendMessage(result ? Utils.translate("&aSuccessfully removed command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name));
+                break;
+            default:
                 sendHelp(sender);
-                return true;
-            }
-
-            Player player = (Player) sender;
-
-            int x, y, z;
-            try {
-                x = Integer.parseInt(a[2]);
-                y = Integer.parseInt(a[3]);
-                z = Integer.parseInt(a[4]);
-            } catch (NumberFormatException ignore) {
-                sendHelp(sender);
-                return true;
-            }
-
-            if (csignManager.commandSignExists(name)) {
-                sender.sendMessage(Utils.translate("&cCommand sign already exists with that name"));
-            } else if (csignManager.commandSignExists(new CmdSignLocation(player.getWorld(), x, y, z))) {
-                sender.sendMessage(Utils.translate("&cCommand sign already exists at that location"));
-            } else {
-                String cmd = String.join(" ", Arrays.copyOfRange(a, 5, a.length));
-                csignManager.addCommandSign(name, cmd, player.getWorld(), x, y, z);
-                sender.sendMessage(Utils.translate("&aSuccessfully created command sign at (" + x + ", " + y + ", " + z + ")"));
-            }
-        } else if (a[0].equalsIgnoreCase("delete")) {
-            if (!csignManager.commandSignExists(name)) {
-                sender.sendMessage(Utils.translate("&cCommand sign does not exist with that name"));
-            } else {
-                csignManager.deleteCommandSign(name);
-                sender.sendMessage(Utils.translate("&aSuccessfully deleted command sign &2" + name));
-            }
-        } else if (a[0].equalsIgnoreCase("modify")) {
-            if (!csignManager.commandSignExists(name)) {
-                sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
-                return true;
-            }
-
-            String cmd = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
-            csignManager.updateCommand(name, cmd);
-            sender.sendMessage(Utils.translate("&aSuccessfully updated command(s) for &2" + name));
-        } else if (a[0].equalsIgnoreCase("broadcast")) {
-            if (!csignManager.commandSignExists(name)) {
-                sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
-                return true;
-            }
-            csignManager.toggleBroadcast(name);
-            sender.sendMessage(Utils.translate("&7Toggled broadcast of &a" + name + "&7 to " + (csignManager.getCommandSign(name).isBroadcast() ? "&atrue" : "&cfalse")));
-        } else if (a[0].equalsIgnoreCase("title")) {
-            if (!csignManager.commandSignExists(name)) {
-                sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
-                return true;
-            }
-
-            String title = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
-            csignManager.updateTitle(name, title);
-            sender.sendMessage(Utils.translate("&7Set title for &2" + name + "&7 to &a" + title));
-        } else {
-            sendHelp(sender);
+                break;
         }
 
         return true;
@@ -131,12 +203,24 @@ public class CommandSignCMD implements CommandExecutor {
         for (CommandSign csign : csigns) {
             CmdSignLocation loc = csign.getLocation();
             List<String> cmds = csign.getCommands();
-            sender.sendMessage(Utils.translate("&a" + csign.getName() + ": " + loc.getWorld().getName() + " (" + loc.getX() + ", " + loc.getY() + ", " + loc.getZ() + ")"));
+            sender.sendMessage(Utils.translate("&a" + csign.getName() + ": " + loc.toString()));
             sender.sendMessage(Utils.translate("  &7Command(s):"));
             for (int i = 0; i < cmds.size(); i++) {
                 sender.sendMessage(Utils.translate("    &2&o" + (i + 1) + ". /") + cmds.get(i));
             }
             sender.sendMessage(Utils.translate("  &7Broadcast: " + (csign.isBroadcast() ? "&atrue" : "&cfalse")));
         }
+    }
+
+    // probably redundant but nice to have in case the list command gets really long
+    private static void showInfo(CommandSender sender, CommandSign csign) {
+        sender.sendMessage(Utils.translate("&a" + csign.getName() + ":"));
+        sender.sendMessage(Utils.translate("  &7title: " + csign.getTitle()));
+        sender.sendMessage(Utils.translate("  &7Location: &2&o" + csign.getLocation().toString()));
+        sender.sendMessage(Utils.translate("  &7Commands:"));
+        for (int i = 0; i < csign.getCommands().size(); i++) {
+            sender.sendMessage(Utils.translate("    &2&o" + (i + 1) + ". /") + csign.getCommands().get(i));
+        }
+        sender.sendMessage(Utils.translate("  &7Broadcast: " + (csign.isBroadcast() ? "&atrue" : "&cfalse")));
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -232,7 +232,7 @@ public class CommandSignCMD implements CommandExecutor {
     // probably redundant but nice to have in case the list command gets really long
     private static void showInfo(CommandSender sender, CommandSign csign) {
         sender.sendMessage(Utils.translate("&a" + csign.getName() + ":"));
-        sender.sendMessage(Utils.translate("  &7title: " + csign.getTitle()));
+        sender.sendMessage(Utils.translate("  &7Title: " + csign.getTitle()));
         sender.sendMessage(Utils.translate("  &7Location: &2&o" + csign.getLocation().toString()));
         sender.sendMessage(Utils.translate("  &7Commands:"));
         for (int i = 0; i < csign.getCommands().size(); i++) {

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -107,8 +107,14 @@ public class CommandSignCMD implements CommandExecutor {
                     sendHelp(sender);
                     return true;
                 }
+
+                if (Utils.containsIgnoreCase(csignManager.getCommandSign(name).getCommands(), cmd)) {
+                    sender.sendMessage(Utils.translate("&cCommand already exists in command sign"));
+                    return true;
+                }
+
                 result = csignManager.updateCommand(name, index, cmd);
-                sender.sendMessage(result ? Utils.translate("&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name));
+                sender.sendMessage(result ? Utils.translate("&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name) : Utils.translate("&cIndex &4" + (index + 1) + " &cdoes not exist for &4" + name));
                 break;
             case "broadcast":
                 if (!csignManager.commandSignExists(name)) {
@@ -146,6 +152,11 @@ public class CommandSignCMD implements CommandExecutor {
                 cmd = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
                 if (cmd.isEmpty()) {
                     sendHelp(sender);
+                    return true;
+                }
+
+                if (Utils.containsIgnoreCase(csignManager.getCommandSign(name).getCommands(), cmd)) {
+                    sender.sendMessage(Utils.translate("&cCommand already exists in command sign"));
                     return true;
                 }
 

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -113,9 +113,13 @@ public class CommandSignCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&2&lCommandSigns Help"));
         sender.sendMessage(Utils.translate("&a/commandsign help  &7Displays this menu"));
         sender.sendMessage(Utils.translate("&a/commandsign list  &7Shows list of all command signs"));
-        sender.sendMessage(Utils.translate("&a/commandsign create <name> <x> <y> <z> <command>  &7Creates uniquely named command sign at supplied integer coordinates"));
-        sender.sendMessage(Utils.translate("&a/commandsign delete <name>  &7Deletes the specified command sign"));
-        sender.sendMessage(Utils.translate("&a/commandsign modify <name> <command>  &7Updates a sign's command"));
+        sender.sendMessage(Utils.translate("&a/commandsign show <name>  &7Displays details of a command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign create <name> <x> <y> <z> [command]  &7Creates uniquely named command sign at supplied integer coordinates"));
+        sender.sendMessage(Utils.translate("    &2&ooptional &2[command]  &7aAdds the singular command to the created command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign delete <name> &7Deletes the specified command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign modify <name> <index> <command>  &7Updates a sign's command at the specified index"));
+        sender.sendMessage(Utils.translate("&a/commandsign add <name> <command>  &7Adds a command to the command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign remove <name> <index>  &7Removes the command at the specified index from the command sign"));
         sender.sendMessage(Utils.translate("&a/commandsign broadcast <name>  &7Toggles broadcast on a sign"));
         sender.sendMessage(Utils.translate("&a/commandsign title <name> <title>  &7Sets sign title"));
     }
@@ -126,11 +130,11 @@ public class CommandSignCMD implements CommandExecutor {
         Collection<CommandSign> csigns = Momentum.getCommandSignManager().getCommandSigns();
         for (CommandSign csign : csigns) {
             CmdSignLocation loc = csign.getLocation();
-            List<String> cmds = CommandSignManager.parseCommand(csign.getCommand());
+            List<String> cmds = csign.getCommands();
             sender.sendMessage(Utils.translate("&a" + csign.getName() + ": " + loc.getWorld().getName() + " (" + loc.getX() + ", " + loc.getY() + ", " + loc.getZ() + ")"));
             sender.sendMessage(Utils.translate("  &7Command(s):"));
-            for (String s : cmds) {
-                sender.sendMessage(Utils.translate("    &2&o/") + s);
+            for (int i = 0; i < cmds.size(); i++) {
+                sender.sendMessage(Utils.translate("    &2&o" + (i + 1) + ". /") + cmds.get(i));
             }
             sender.sendMessage(Utils.translate("  &7Broadcast: " + (csign.isBroadcast() ? "&atrue" : "&cfalse")));
         }

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 public class CommandSignCMD implements CommandExecutor {
 
@@ -84,6 +85,7 @@ public class CommandSignCMD implements CommandExecutor {
 
             String cmd = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
             csignManager.updateCommand(name, cmd);
+            sender.sendMessage(Utils.translate("&aSuccessfully updated command(s) for &2" + name));
         } else if (a[0].equalsIgnoreCase("broadcast")) {
             if (!csignManager.commandSignExists(name)) {
                 sender.sendMessage(Utils.translate("&cNo command sign exists with name &4" + name));
@@ -99,7 +101,7 @@ public class CommandSignCMD implements CommandExecutor {
 
             String title = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
             csignManager.updateTitle(name, title);
-            sender.sendMessage(Utils.translate("&7Set title for &a" + name + "&7 to " + title));
+            sender.sendMessage(Utils.translate("&7Set title for &2" + name + "&7 to &a" + title));
         } else {
             sendHelp(sender);
         }
@@ -116,7 +118,6 @@ public class CommandSignCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/commandsign modify <name> <command>  &7Updates a sign's command"));
         sender.sendMessage(Utils.translate("&a/commandsign broadcast <name>  &7Toggles broadcast on a sign"));
         sender.sendMessage(Utils.translate("&a/commandsign title <name> <title>  &7Sets sign title"));
-        sender.sendMessage(Utils.translate("&a/commandsign help  &7Displays this page"));
     }
 
     private static void showList(CommandSender sender) {
@@ -125,8 +126,12 @@ public class CommandSignCMD implements CommandExecutor {
         Collection<CommandSign> csigns = Momentum.getCommandSignManager().getCommandSigns();
         for (CommandSign csign : csigns) {
             CmdSignLocation loc = csign.getLocation();
+            List<String> cmds = CommandSignManager.parseCommand(csign.getCommand());
             sender.sendMessage(Utils.translate("&a" + csign.getName() + ": " + loc.getWorld().getName() + " (" + loc.getX() + ", " + loc.getY() + ", " + loc.getZ() + ")"));
-            sender.sendMessage(Utils.translate("  &7Command: &2&o/" + csign.getCommand()));
+            sender.sendMessage(Utils.translate("  &7Command(s):"));
+            for (String s : cmds) {
+                sender.sendMessage(Utils.translate("    &2&o/") + s);
+            }
             sender.sendMessage(Utils.translate("  &7Broadcast: " + (csign.isBroadcast() ? "&atrue" : "&cfalse")));
         }
     }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignLocation.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignLocation.java
@@ -53,6 +53,11 @@ public class CmdSignLocation {
     }
 
     @Override
+    public String toString() {
+        return String.format("%s(%d,%d,%d)", world.getName(), x, y, z);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(world.getName(), x, y, z);
     }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -88,7 +88,7 @@ public class CmdSignsDB {
 
     public static void updateCommand(String name, String oldCommand, String newCommand) {
         DatabaseQueries.runAsyncQuery(
-                "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=? LIMIT 1", // limit 1 for duplicate commands
+                "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=?",
                 newCommand, name, oldCommand
         );
     }
@@ -102,7 +102,7 @@ public class CmdSignsDB {
 
     public static void removeCommand(String name, String command) {
         DatabaseQueries.runAsyncQuery(
-                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=? AND command=? LIMIT 1", // limit 1 for duplicate commands
+                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=? AND command=?",
                 name, command
         );
     }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -107,6 +107,13 @@ public class CmdSignsDB {
         );
     }
 
+    public static void removeAllCommands(String name) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=?",
+                name
+        );
+    }
+
     public static void toggleBroadcast(String name) {
         DatabaseQueries.runAsyncQuery(
                 "UPDATE " + DatabaseManager.COMMAND_SIGNS + " SET broadcast=NOT broadcast WHERE name=?", name

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -22,13 +22,7 @@ public class CmdSignsDB {
 
         for (Map<String, String> result : results) {
             String name = result.get("name");
-            // String command = result.get("command");
-            List<String> commands = DatabaseQueries.getResults(
-                    DatabaseManager.COMMAND_SIGNS_COMMANDS,
-                    "*",
-                    "WHERE name=?",
-                    name
-            ).stream().map(res -> res.get("command")).collect(Collectors.toList());
+            List<String> commands = loadCommandSignCommands(name);
             String title = result.get("title");
             World world = Bukkit.getWorld(result.get("world"));
             int x = Integer.parseInt(result.get("x"));
@@ -53,6 +47,15 @@ public class CmdSignsDB {
         for (Map<String, String> result : results) {
             playerStats.addCommandSign(result.get("name"));
         }
+    }
+
+    private static List<String> loadCommandSignCommands(String name) {
+        return DatabaseQueries.getResults(
+                DatabaseManager.COMMAND_SIGNS_COMMANDS,
+                "*",
+                "WHERE name=?",
+                name
+        ).stream().map(res -> res.get("command")).collect(Collectors.toList());
     }
 
     public static void insertCommandSign(String name, String command, String world, int x, int y, int z) {
@@ -85,7 +88,7 @@ public class CmdSignsDB {
 
     public static void updateCommand(String name, String oldCommand, String newCommand) {
         DatabaseQueries.runAsyncQuery(
-                "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=?",
+                "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=? LIMIT 1", // limit 1 for duplicate commands
                 newCommand, name, oldCommand
         );
     }
@@ -99,7 +102,7 @@ public class CmdSignsDB {
 
     public static void removeCommand(String name, String command) {
         DatabaseQueries.runAsyncQuery(
-                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=? AND command=?",
+                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=? AND command=? LIMIT 1", // limit 1 for duplicate commands
                 name, command
         );
     }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -7,6 +7,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.World;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CmdSignsDB {
 
@@ -21,7 +22,13 @@ public class CmdSignsDB {
 
         for (Map<String, String> result : results) {
             String name = result.get("name");
-            String command = result.get("command");
+            // String command = result.get("command");
+            List<String> commands = DatabaseQueries.getResults(
+                    DatabaseManager.COMMAND_SIGNS_COMMANDS,
+                    "*",
+                    "WHERE name=?",
+                    name
+            ).stream().map(res -> res.get("command")).collect(Collectors.toList());
             String title = result.get("title");
             World world = Bukkit.getWorld(result.get("world"));
             int x = Integer.parseInt(result.get("x"));
@@ -29,7 +36,7 @@ public class CmdSignsDB {
             int z = Integer.parseInt(result.get("z"));
             boolean broadcast = Integer.parseInt(result.get("broadcast")) == 1;
 
-            temp.put(name, new CommandSign(name, title, command, new CmdSignLocation(world, x, y, z), broadcast));
+            temp.put(name, new CommandSign(name, title, commands, new CmdSignLocation(world, x, y, z), broadcast));
         }
 
         return temp;
@@ -76,10 +83,24 @@ public class CmdSignsDB {
         );
     }
 
-    public static void updateCommand(String name, String newCommand) {
+    public static void updateCommand(String name, String oldCommand, String newCommand) {
         DatabaseQueries.runAsyncQuery(
-                "UPDATE " + DatabaseManager.COMMAND_SIGNS + " SET command=? WHERE name=?",
-                newCommand, name
+                "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=?",
+                newCommand, name, oldCommand
+        );
+    }
+
+    public static void addCommand(String name, String command) {
+        DatabaseQueries.runAsyncQuery(
+                "INSERT INTO " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " (name, command) VALUES (?,?)",
+                name, command
+        );
+    }
+
+    public static void removeCommand(String name, String command) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " WHERE name=? AND command=?",
+                name, command
         );
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSign.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSign.java
@@ -1,17 +1,19 @@
 package com.renatusnetwork.momentum.data.cmdsigns;
 
+import java.util.List;
+
 public class CommandSign {
 
     private String name;
     private String title;
-    private String command;
+    private List<String> commands;
     private CmdSignLocation location;
     private boolean broadcast;
 
-    public CommandSign(String name, String title, String command, CmdSignLocation location, boolean broadcast) {
+    public CommandSign(String name, String title, List<String> commands, CmdSignLocation location, boolean broadcast) {
         this.name = name;
         this.title = title;
-        this.command = command;
+        this.commands = commands;
         this.location = location;
         this.broadcast = broadcast;
     }
@@ -24,12 +26,21 @@ public class CommandSign {
         return this.location;
     }
 
-    public String getCommand() {
-        return this.command;
+    public List<String> getCommands() {
+        return this.commands;
     }
 
-    public void updateCommand(String newCommand) {
-        this.command = newCommand;
+    public void updateCommand(int index, String newCommand) {
+        this.commands.set(index, newCommand);
+    }
+
+    public void addCommand(String newCommand) {
+        this.commands.add(newCommand);
+    }
+
+    // returns the command that was removed
+    public String removeCommand(int index) {
+        return this.commands.remove(index);
     }
 
     public boolean isBroadcast() {

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSign.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSign.java
@@ -4,10 +4,10 @@ import java.util.List;
 
 public class CommandSign {
 
-    private String name;
+    private final String name;
     private String title;
-    private List<String> commands;
-    private CmdSignLocation location;
+    private final List<String> commands;
+    private final CmdSignLocation location;
     private boolean broadcast;
 
     public CommandSign(String name, String title, List<String> commands, CmdSignLocation location, boolean broadcast) {
@@ -41,6 +41,10 @@ public class CommandSign {
     // returns the command that was removed
     public String removeCommand(int index) {
         return this.commands.remove(index);
+    }
+
+    public void clearCommands() {
+        this.commands.clear();
     }
 
     public boolean isBroadcast() {

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -27,7 +27,7 @@ public class CommandSignManager {
 
     public void addCommandSign(String name, String command, World world, int x, int y, int z) {
         CmdSignLocation loc = new CmdSignLocation(world, x, y, z);
-        CommandSign csign = new CommandSign(name, null, command == null ? new ArrayList<>() : Collections.singletonList(command), loc, false);
+        CommandSign csign = new CommandSign(name, null, command == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(command)), loc, false);
 
         cmdSigns.put(name, csign);
         locations.put(loc, csign);

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -27,7 +27,7 @@ public class CommandSignManager {
 
     public void addCommandSign(String name, String command, World world, int x, int y, int z) {
         CmdSignLocation loc = new CmdSignLocation(world, x, y, z);
-        CommandSign csign = new CommandSign(name, null, Collections.singletonList(command), loc, false);
+        CommandSign csign = new CommandSign(name, null, command == null ? new ArrayList<>() : Collections.singletonList(command), loc, false);
 
         cmdSigns.put(name, csign);
         locations.put(loc, csign);
@@ -62,10 +62,16 @@ public class CommandSignManager {
         return locations.containsKey(location);
     }
 
-    public void updateCommand(String name, int index, String newCommand) {
-        String oldCommand = cmdSigns.get(name).getCommands().get(index);
-        cmdSigns.get(name).updateCommand(index, newCommand);
+    // returns true if index is in bounds
+    public boolean updateCommand(String name, int index, String newCommand) {
+        CommandSign csign = cmdSigns.get(name);
+        if (index < 0 || index >= csign.getCommands().size()) {
+            return false;
+        }
+        String oldCommand = csign.getCommands().get(index);
+        csign.updateCommand(index, newCommand);
         CmdSignsDB.updateCommand(name, oldCommand, newCommand);
+        return true;
     }
 
     public void addCommand(String name, String command) {
@@ -73,9 +79,15 @@ public class CommandSignManager {
         CmdSignsDB.addCommand(name, command);
     }
 
-    public void removeCommand(String name, int index) {
+    // returns true if index is in bounds
+    public boolean removeCommand(String name, int index) {
+        CommandSign csign = cmdSigns.get(name);
+        if (index < 0 || index >= csign.getCommands().size()) {
+            return false;
+        }
         String cmd = cmdSigns.get(name).removeCommand(index);
         CmdSignsDB.removeCommand(name, cmd);
+        return true;
     }
 
     public CommandSign getCommandSign(String name) {

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -27,7 +27,7 @@ public class CommandSignManager {
 
     public void addCommandSign(String name, String command, World world, int x, int y, int z) {
         CmdSignLocation loc = new CmdSignLocation(world, x, y, z);
-        CommandSign csign = new CommandSign(name, null, command, loc, false);
+        CommandSign csign = new CommandSign(name, null, Collections.singletonList(command), loc, false);
 
         cmdSigns.put(name, csign);
         locations.put(loc, csign);
@@ -62,9 +62,20 @@ public class CommandSignManager {
         return locations.containsKey(location);
     }
 
-    public void updateCommand(String name, String newCommand) {
-        cmdSigns.get(name).updateCommand(newCommand);
-        CmdSignsDB.updateCommand(name, newCommand);
+    public void updateCommand(String name, int index, String newCommand) {
+        String oldCommand = cmdSigns.get(name).getCommands().get(index);
+        cmdSigns.get(name).updateCommand(index, newCommand);
+        CmdSignsDB.updateCommand(name, oldCommand, newCommand);
+    }
+
+    public void addCommand(String name, String command) {
+        cmdSigns.get(name).addCommand(command);
+        CmdSignsDB.addCommand(name, command);
+    }
+
+    public void removeCommand(String name, int index) {
+        String cmd = cmdSigns.get(name).removeCommand(index);
+        CmdSignsDB.removeCommand(name, cmd);
     }
 
     public CommandSign getCommandSign(String name) {
@@ -77,13 +88,5 @@ public class CommandSignManager {
 
     public Collection<CommandSign> getCommandSigns() {
         return cmdSigns.values();
-    }
-
-    // splits string at every ampersand character ('&') if and only if it is not escaped (preceded by a backslash) ('\')
-    // returns list with each entry being the argument split according to the above criteria
-    public static List<String> parseCommand(String cmd) {
-        // first regex: negative look behind, only matches ampersands preceded by a backslash
-        // second regex: positive look ahead, only matches backslashes followed by an ampersand
-        return Arrays.stream(cmd.split("(?<!\\\\)&")).filter(s -> !s.isEmpty()).map(s -> s.replaceAll("\\\\(?=&)", "")).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -4,6 +4,7 @@ import com.renatusnetwork.momentum.data.stats.PlayerStats;
 import org.bukkit.World;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CommandSignManager {
 
@@ -76,5 +77,13 @@ public class CommandSignManager {
 
     public Collection<CommandSign> getCommandSigns() {
         return cmdSigns.values();
+    }
+
+    // splits string at every ampersand character ('&') if and only if it is not escaped (preceded by a backslash) ('\')
+    // returns list with each entry being the argument split according to the above criteria
+    public static List<String> parseCommand(String cmd) {
+        // first regex: negative look behind, only matches ampersands preceded by a backslash
+        // second regex: positive look ahead, only matches backslashes followed by an ampersand
+        return Arrays.stream(cmd.split("(?<!\\\\)&")).filter(s -> !s.isEmpty()).map(s -> s.replaceAll("\\\\(?=&)", "")).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -90,6 +90,11 @@ public class CommandSignManager {
         return true;
     }
 
+    public void clearCommands(String name) {
+        cmdSigns.get(name).clearCommands();
+        CmdSignsDB.removeAllCommands(name);
+    }
+
     public CommandSign getCommandSign(String name) {
         return cmdSigns.get(name);
     }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -212,9 +212,7 @@ public class InteractListener implements Listener {
                 if (!playerStats.hasCommandSign(csign.getName())) {
                     csignManager.useCommandSign(playerStats, csign.getName());
 
-                    // command parsing for multiple commands
-                    String cmd = csign.getCommand();
-                    for (String s : CommandSignManager.parseCommand(cmd)) {
+                    for (String s : csign.getCommands()) {
                         Bukkit.dispatchCommand(Bukkit.getConsoleSender(), s.replaceAll("%player%", playerStats.getName()));
                     }
 

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -212,9 +212,7 @@ public class InteractListener implements Listener {
                 if (!playerStats.hasCommandSign(csign.getName())) {
                     csignManager.useCommandSign(playerStats, csign.getName());
 
-                    for (String s : csign.getCommands()) {
-                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), s.replaceAll("%player%", playerStats.getName()));
-                    }
+                    csign.getCommands().forEach(cmd -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), s.replaceAll("%player%", playerStats.getName())));
 
                     if (csign.isBroadcast()) {
                         Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 claimed the sign &2" + csign.getTitle()));

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -24,7 +24,7 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.HashMap;
+import java.util.*;
 
 public class InteractListener implements Listener {
 
@@ -211,10 +211,15 @@ public class InteractListener implements Listener {
             if (playerStats != null && playerStats.isLoaded() && csign != null) {
                 if (!playerStats.hasCommandSign(csign.getName())) {
                     csignManager.useCommandSign(playerStats, csign.getName());
-                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), csign.getCommand().replaceAll("%player%", playerStats.getName()));
+
+                    // command parsing for multiple commands
+                    String cmd = csign.getCommand();
+                    for (String s : CommandSignManager.parseCommand(cmd)) {
+                        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), s.replaceAll("%player%", playerStats.getName()));
+                    }
 
                     if (csign.isBroadcast()) {
-                        Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 claimed the sign " + csign.getTitle()));
+                        Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 claimed the sign &2" + csign.getTitle()));
                     } else {
                         player.sendMessage(Utils.translate("&aYou have claimed this sign"));
                     }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -212,7 +212,7 @@ public class InteractListener implements Listener {
                 if (!playerStats.hasCommandSign(csign.getName())) {
                     csignManager.useCommandSign(playerStats, csign.getName());
 
-                    csign.getCommands().forEach(cmd -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), s.replaceAll("%player%", playerStats.getName())));
+                    csign.getCommands().forEach(cmd -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replaceAll("%player%", playerStats.getName())));
 
                     if (csign.isBroadcast()) {
                         Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 claimed the sign &2" + csign.getTitle()));

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/DatabaseManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/DatabaseManager.java
@@ -42,6 +42,7 @@ public class DatabaseManager {
     public static final String BANK_BIDS = "bank_bids";
     public static final String COMMAND_SIGNS = "command_signs";
     public static final String USED_COMMAND_SIGNS = "used_command_signs";
+    public static final String COMMAND_SIGNS_COMMANDS = "command_signs_commands";
 
     public DatabaseManager(Plugin plugin) {
         connection = new DatabaseConnection();

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
@@ -75,6 +75,7 @@ public class TablesDB {
         createBankBids();
         createCommandSigns();
         createUsedCommandSigns();
+        createCommandSignsCommands();
     }
 
     private static void createKeys() {
@@ -103,6 +104,7 @@ public class TablesDB {
         createBankWeeksKeys();
         createBankBidsKeys();
         createUsedCommandSignsKeys();
+        createCommandSignsCommandsKeys();
     }
 
     private static void createPlayers() {
@@ -916,12 +918,13 @@ public class TablesDB {
                 "CREATE TABLE " + DatabaseManager.COMMAND_SIGNS + "(" +
                 "name VARCHAR(20) NOT NULL, " +
                 "title VARCHAR(50) DEFAULT NULL, " +
-                "command VARCHAR(100) DEFAULT NULL, " +
+                // "command VARCHAR(100) DEFAULT NULL, " + // moved to a cmds db
                 "world VARCHAR(30) NOT NULL, " +
                 "x INT NOT NULL, " +
                 "y INT NOT NULL, " +
                 "z INT NOT NULL, " +
                 "broadcast BIT DEFAULT 0, " +
+                // primary keys
                 "PRIMARY KEY (name)" +
                 ")";
 
@@ -942,6 +945,18 @@ public class TablesDB {
         DatabaseQueries.runQuery(query);
     }
 
+    private static void createCommandSignsCommands() {
+        String query =
+                "CREATE TABLE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + "(" +
+                "name VARCHAR(20) NOT NULL, " +
+                "command VARCHAR(100) DEFAULT NULL, " +
+                // primary keys
+                "PRIMARY KEY (name)" +
+                ")";
+
+        DatabaseQueries.runQuery(query);
+    }
+
     private static void createUsedCommandSignsKeys() {
         String foreignKeyQuery = "ALTER TABLE " + DatabaseManager.USED_COMMAND_SIGNS +
                                  "ADD CONSTRAINT " + DatabaseManager.USED_COMMAND_SIGNS + "_uuid_fk " +
@@ -949,6 +964,16 @@ public class TablesDB {
                                  "ON UPDATE CASCADE " +
                                  "ON DELETE CASCADE, " +
                                  "ADD CONSTRAINT " + DatabaseManager.USED_COMMAND_SIGNS + "_name_fk " +
+                                 "FOREIGN KEY (name) REFERENCES " + DatabaseManager.COMMAND_SIGNS + " (name) " +
+                                 "ON UPDATE CASCADE " +
+                                 "ON DELETE CASCADE";
+
+        DatabaseQueries.runQuery(foreignKeyQuery);
+    }
+
+    private static void createCommandSignsCommandsKeys() {
+        String foreignKeyQuery = "ALTER TABLE " + DatabaseManager.COMMAND_SIGNS_COMMANDS +
+                                 "ADD CONSTRAINT " + DatabaseManager.COMMAND_SIGNS_COMMANDS + "_name_fk " +
                                  "FOREIGN KEY (name) REFERENCES " + DatabaseManager.COMMAND_SIGNS + " (name) " +
                                  "ON UPDATE CASCADE " +
                                  "ON DELETE CASCADE";

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
@@ -950,7 +950,7 @@ public class TablesDB {
                 "name VARCHAR(20) NOT NULL, " +
                 "command VARCHAR(100) DEFAULT NULL, " +
                 // primary keys
-                "PRIMARY KEY (name)" +
+                "PRIMARY KEY (name, command)" +
                 ")";
 
         DatabaseQueries.runQuery(query);

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
@@ -918,7 +918,6 @@ public class TablesDB {
                 "CREATE TABLE " + DatabaseManager.COMMAND_SIGNS + "(" +
                 "name VARCHAR(20) NOT NULL, " +
                 "title VARCHAR(50) DEFAULT NULL, " +
-                // "command VARCHAR(100) DEFAULT NULL, " + // moved to a cmds db
                 "world VARCHAR(30) NOT NULL, " +
                 "x INT NOT NULL, " +
                 "y INT NOT NULL, " +

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -452,4 +452,8 @@ public class Utils {
     public static void applySlowness(Player player   /* in ticks */) {
         player.addPotionEffect(PotionEffectType.SLOW.createEffect(20, 255));
     }
+
+    public static boolean containsIgnoreCase(List<String> strings, String match) { // non regex friendly
+        return strings.stream().anyMatch(s -> s.equalsIgnoreCase(match));
+    }
 }


### PR DESCRIPTION
- added support for multiple commands being executed by one command sign (command1&command2...). ampersands can be escaped to not separate commands (broadcast apple \\& banana & broadcast mango \\& pear -> broadcasts "apple & banana" and "mango & pear" separately)
- tweaked colors in the cmdsign command
- tweaked cmdsign command help message