### PR TITLE
V3 Release Patches

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/commands/ELOCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ELOCMD.java
@@ -1,6 +1,7 @@
 package com.renatusnetwork.momentum.commands;
 
 import com.renatusnetwork.momentum.Momentum;
+import com.renatusnetwork.momentum.data.elo.ELOTier;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
 import com.renatusnetwork.momentum.utils.Utils;
 import org.bukkit.Bukkit;
@@ -28,6 +29,8 @@ public class ELOCMD implements CommandExecutor {
                         int elo = Math.max(Integer.parseInt(a[2]), 0);
 
                         Momentum.getStatsManager().updateELOData(targetStats, elo);
+                        Momentum.getStatsManager().updateELOTier(targetStats, Momentum.getELOTiersManager().calculateELOTierDirectly(elo));
+                        targetStats.loadELOToXPBar();
                         player.sendMessage(Utils.translate("&7You have set &c" + targetStats.getDisplayName() + "&7's &aELO&7 to &2" + Utils.formatNumber(elo)));
                     } else {
                         player.sendMessage(Utils.translate("&4" + a[2] + " is not an integer"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
@@ -10,6 +10,7 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 
 import java.util.Arrays;
+import java.util.List;
 
 public class ELOTierCMD implements CommandExecutor {
     @Override
@@ -33,6 +34,16 @@ public class ELOTierCMD implements CommandExecutor {
                     sender.sendMessage(Utils.translate("&7You have created the ELO tier &c" + name));
                 } else {
                     sender.sendMessage(Utils.translate("&4" + name + " &calready exists"));
+                }
+            } else if (a.length == 1 && a[0].equalsIgnoreCase("list")) {
+                sendELOTiers(sender);
+            } else if (a.length == 2 && a[0].equalsIgnoreCase("tier")) {
+                PlayerStats playerStats = Momentum.getStatsManager().getByName(a[1]);
+                if (playerStats != null) {
+                    sender.sendMessage(Utils.translate(playerStats.getDisplayName() + " &7is " + playerStats.getELOTier().getFormattedTitle()));
+                }
+                else {
+                    sender.sendMessage(Utils.translate("&4" + a[1] + " &cis not online"));
                 }
             } else if (a.length == 2 && a[0].equalsIgnoreCase("loadxpbar")) {
                 PlayerStats playerStats = Momentum.getStatsManager().getByName(a[1]);
@@ -93,6 +104,8 @@ public class ELOTierCMD implements CommandExecutor {
 
                         if (tier != null) {
                             Momentum.getStatsManager().updateELOTier(playerStats, tier);
+                            Momentum.getStatsManager().updateELOData(playerStats, tier.getRequiredELO());
+                            playerStats.loadELOToXPBar();
                             sender.sendMessage(Utils.translate("&7You have set &c" + playerStats.getName() + "&7's ELO tier to &a" + tier.getTitle()));
                         }
                     } else {
@@ -112,10 +125,19 @@ public class ELOTierCMD implements CommandExecutor {
         ELOTier eloTier = Momentum.getELOTiersManager().get(name);
 
         if (eloTier == null) {
-            sender.sendMessage(Utils.translate("&4" + name + " &cis not a ELO tier"));
+            sender.sendMessage(Utils.translate("&4" + name + " &cis not an ELO tier"));
         }
 
         return eloTier;
+    }
+
+    private void sendELOTiers(CommandSender sender) {
+        List<ELOTier> tiers = Momentum.getELOTiersManager().getAll();
+
+        for (ELOTier tier : tiers) {
+            ELOTier nextTier = tier.getNextELOTier();
+            sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")" + (nextTier != null ? "  &7->  " + nextTier.getFormattedTitle() : "")));
+        }
     }
 
     private void sendHelp(CommandSender sender) {
@@ -127,6 +149,7 @@ public class ELOTierCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/elotier previous (name) (previousTier)  &7Sets a tier's previous name"));
         sender.sendMessage(Utils.translate("&a/elotier set (player) (name)  &7Set a player's tier"));
         sender.sendMessage(Utils.translate("&a/elotier loadxpbar (player)  &7Recalculates and loads new xp bar on ELO/ELO tier"));
+        sender.sendMessage(Utils.translate("&a/elotier list  &7Displays all ELO tiers"));
         sender.sendMessage(Utils.translate("&a/elotier help  &7Shows this page"));
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
@@ -132,12 +132,17 @@ public class ELOTierCMD implements CommandExecutor {
     }
 
     private void sendELOTiers(CommandSender sender) {
-        List<ELOTier> tiers = Momentum.getELOTiersManager().getAll();
+        ELOTier tier = Momentum.getELOTiersManager().get(Momentum.getSettingsManager().default_elo_tier);
+        ELOTier next = tier.getNextELOTier();
 
-        for (ELOTier tier : tiers) {
-            ELOTier nextTier = tier.getNextELOTier();
-            sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")" + (nextTier != null ? "  &7->  " + nextTier.getFormattedTitle() : "")));
+        while (next != null) {
+            sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")  &7->  " + next.getFormattedTitle()));
+
+            tier = next;
+            next = tier.getNextELOTier();
         }
+
+        sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")"));
     }
 
     private void sendHelp(CommandSender sender) {

--- a/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
@@ -149,6 +149,7 @@ public class ELOTierCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/elotier previous (name) (previousTier)  &7Sets a tier's previous name"));
         sender.sendMessage(Utils.translate("&a/elotier set (player) (name)  &7Set a player's tier"));
         sender.sendMessage(Utils.translate("&a/elotier loadxpbar (player)  &7Recalculates and loads new xp bar on ELO/ELO tier"));
+        sender.sendMessage(Utils.translate("&a/elotier tier (player)  &7Displays the ELO tier of a player"));
         sender.sendMessage(Utils.translate("&a/elotier list  &7Displays all ELO tiers"));
         sender.sendMessage(Utils.translate("&a/elotier help  &7Shows this page"));
     }

--- a/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
@@ -2,6 +2,7 @@ package com.renatusnetwork.momentum.commands;
 
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.data.infinite.*;
+import com.renatusnetwork.momentum.data.infinite.gamemode.Infinite;
 import com.renatusnetwork.momentum.data.infinite.gamemode.InfiniteType;
 import com.renatusnetwork.momentum.data.infinite.rewards.InfiniteReward;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
@@ -31,6 +32,14 @@ public class InfiniteCMD implements CommandExecutor {
 
         if (player.hasPermission("momentum.admin") && a.length == 1 && a[0].equalsIgnoreCase("modes")) {
             sendTypes(player);
+        } else if (a.length == 1 && a[0].equalsIgnoreCase("quit")) {
+            if (!Momentum.getStatsManager().get(player).isInInfinite()) {
+                sender.sendMessage(Utils.translate("&cYou are not in infinite parkour!"));
+                return false;
+            }
+
+            infiniteManager.endPK(player);
+            sender.sendMessage(Utils.translate("&7You have successfully ended your current infinite session"));
         } else if (a.length >= 2 && a[0].equalsIgnoreCase("score")) {
             InfiniteType type = infiniteManager.getType(a[1].toUpperCase());
             if (type == null) {
@@ -195,7 +204,7 @@ public class InfiniteCMD implements CommandExecutor {
         player.sendMessage(Utils.translate("&5/infinite start  &7Starts Infinite Parkour"));
         player.sendMessage(Utils.translate("&5/infinite score <type> [IGN]  &7Tells you the score of yourself/someone else"));
         player.sendMessage(Utils.translate("&5/infinite rewards <type>  &7Tells you a list of the rewards for the type and if you have them (crossed out)"));
-
+        player.sendMessage(Utils.translate("&5/infinite quit  &7Ends your current infinite session"));
 
         if (player.hasPermission("momentum.admin")) {
             player.sendMessage(Utils.translate("&5/infinite setscore <IGN> <type> <score>  &7Set the type's score of someone"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
@@ -28,8 +28,16 @@ public class InfiniteCMD implements CommandExecutor {
         Player player = (Player) sender;
         InfiniteManager infiniteManager = Momentum.getInfiniteManager();
 
-        if (a.length >= 2 && a[0].equalsIgnoreCase("score")) {
-            InfiniteType type = InfiniteType.valueOf(a[1].toUpperCase());
+        if (player.hasPermission("momentum.admin") && a.length == 1 && a[0].equalsIgnoreCase("modes")) {
+            sendTypes(player);
+        } else if (a.length >= 2 && a[0].equalsIgnoreCase("score")) {
+            InfiniteType type = infiniteManager.getType(a[1].toUpperCase());
+            if (type == null) {
+                player.sendMessage(Utils.translate("&cInvalid infinite type &4" + a[1].toUpperCase() + "&c!"));
+                sendTypes(player);
+                return true;
+            }
+
             // other target
             if (a.length == 3) {
                 Player target = Bukkit.getPlayer(a[2]);
@@ -49,7 +57,13 @@ public class InfiniteCMD implements CommandExecutor {
             if (Utils.isInteger(a[3])) {
                 StatsManager statsManager = Momentum.getStatsManager();
 
-                InfiniteType type = InfiniteType.valueOf(a[2].toUpperCase());
+                InfiniteType type = infiniteManager.getType(a[2].toUpperCase());
+                if (type == null) {
+                    player.sendMessage(Utils.translate("&cInvalid infinite type &4" + a[2].toUpperCase() + "&c!"));
+                    sendTypes(player);
+                    return true;
+                }
+
                 PlayerStats playerStats = statsManager.getByName(a[1]);
                 int score = Integer.parseInt(a[3]);
 
@@ -70,14 +84,19 @@ public class InfiniteCMD implements CommandExecutor {
         } else if (player.hasPermission("momentum.admin") && (a.length == 3 && a[0].equalsIgnoreCase("mode"))) {
             String targetName = a[1];
             String mode = a[2];
-            InfiniteType infiniteType = InfiniteType.valueOf(mode.toUpperCase());
+            InfiniteType type = infiniteManager.getType(mode.toUpperCase());
+            if (type == null) {
+                player.sendMessage(Utils.translate("&cInvalid infinite type &4" + mode.toUpperCase() + "&c!"));
+                sendTypes(player);
+                return true;
+            }
 
             Player target = Bukkit.getPlayer(targetName);
 
             if (target != null) {
                 PlayerStats targetStats = Momentum.getStatsManager().get(target);
-                infiniteManager.changeType(targetStats, infiniteType);
-                player.sendMessage(Utils.translate("&7You changed &c" + targetName + "&7's infinite type to &4" + infiniteType));
+                infiniteManager.changeType(targetStats, type);
+                player.sendMessage(Utils.translate("&7You changed &c" + targetName + "&7's infinite type to &4" + type));
             } else {
                 player.sendMessage(Utils.translate("&4" + targetName + " &cis not online"));
             }
@@ -122,7 +141,12 @@ public class InfiniteCMD implements CommandExecutor {
             String typeName = a[1];
             try {
                 // get rewards
-                InfiniteType type = InfiniteType.valueOf(typeName.toUpperCase());
+                InfiniteType type = infiniteManager.getType(typeName.toUpperCase());
+                if (type == null) {
+                    player.sendMessage(Utils.translate("&cInvalid infinite type &4" + typeName.toUpperCase() + "&c!"));
+                    sendTypes(player);
+                    return true;
+                }
                 List<InfiniteReward> rewards = Momentum.getInfiniteManager().getRewards(type).getRewards();
 
                 player.sendMessage(Utils.translate("&d&l" + StringUtils.capitalize(typeName.toLowerCase()) + " &5&lInfinite Rewards"));
@@ -162,14 +186,24 @@ public class InfiniteCMD implements CommandExecutor {
     private void sendHelp(Player player) {
         player.sendMessage(Utils.translate("&5/infinite start  &7Starts Infinite Parkour"));
         player.sendMessage(Utils.translate("&5/infinite score <type> [IGN]  &7Tells you the score of yourself/someone else"));
-        player.sendMessage(Utils.translate("&5/infinite rewards <type> &7Tells you a list of the rewards for the type and if you have them (crossed out)"));
+        player.sendMessage(Utils.translate("&5/infinite rewards <type>  &7Tells you a list of the rewards for the type and if you have them (crossed out)"));
+
 
         if (player.hasPermission("momentum.admin")) {
             player.sendMessage(Utils.translate("&5/infinite setscore <IGN> <type> <score>  &7Set the type's score of someone"));
             player.sendMessage(Utils.translate("&5/infinite loadrewards  &7Loads rewards from rewards.yml"));
             player.sendMessage(Utils.translate("&5/infinite mode <IGN> <type>  &7Set the mode of a player"));
+            player.sendMessage(Utils.translate("&5/infinite modes  &7Lists the infinite modes"));
         }
 
         player.sendMessage(Utils.translate("&5/infinite help  &7Shows you this display"));
+    }
+
+    private void sendTypes(Player player) {
+        player.sendMessage(Utils.translate("&5Infinite Parkour Types"));
+        player.sendMessage(Utils.translate("&7CLASSIC"));
+        player.sendMessage(Utils.translate("&7SPEEDRUN"));
+        player.sendMessage(Utils.translate("&7TIMED"));
+        player.sendMessage(Utils.translate("&7SPRINT"));
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
@@ -39,7 +39,7 @@ public class InfiniteCMD implements CommandExecutor {
             }
 
             infiniteManager.endPK(player);
-            sender.sendMessage(Utils.translate("&7You have successfully ended your current infinite session"));
+            sender.sendMessage(Utils.translate("&7You have ended your infinite run"));
         } else if (a.length >= 2 && a[0].equalsIgnoreCase("score")) {
             InfiniteType type = infiniteManager.getType(a[1].toUpperCase());
             if (type == null) {
@@ -204,7 +204,7 @@ public class InfiniteCMD implements CommandExecutor {
         player.sendMessage(Utils.translate("&5/infinite start  &7Starts Infinite Parkour"));
         player.sendMessage(Utils.translate("&5/infinite score <type> [IGN]  &7Tells you the score of yourself/someone else"));
         player.sendMessage(Utils.translate("&5/infinite rewards <type>  &7Tells you a list of the rewards for the type and if you have them (crossed out)"));
-        player.sendMessage(Utils.translate("&5/infinite quit  &7Ends your current infinite session"));
+        player.sendMessage(Utils.translate("&5/infinite quit  &7Ends your current infinite run"));
 
         if (player.hasPermission("momentum.admin")) {
             player.sendMessage(Utils.translate("&5/infinite setscore <IGN> <type> <score>  &7Set the type's score of someone"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/InfiniteCMD.java
@@ -5,6 +5,7 @@ import com.renatusnetwork.momentum.data.infinite.*;
 import com.renatusnetwork.momentum.data.infinite.gamemode.InfiniteType;
 import com.renatusnetwork.momentum.data.infinite.rewards.InfiniteReward;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
+import com.renatusnetwork.momentum.data.stats.StatsDB;
 import com.renatusnetwork.momentum.data.stats.StatsManager;
 import com.renatusnetwork.momentum.utils.Utils;
 import org.apache.commons.lang.StringUtils;
@@ -45,7 +46,14 @@ public class InfiniteCMD implements CommandExecutor {
                     int score = Momentum.getStatsManager().get(target).getBestInfiniteScore(type);
                     sender.sendMessage(Utils.translate("&c" + a[2] + " &7has a &c" + StringUtils.capitalize(type.toString().toLowerCase()) + " &7score of &6" + Utils.formatNumber(score)));
                 } else {
-                    sender.sendMessage(Utils.translate("&4" + a[2] + " &cis not online"));
+                    // sender.sendMessage(Utils.translate("&4" + a[2] + " &cis not online"));
+                    int score = StatsDB.getPlayerInfiniteHighscore(a[2], type);
+                    if (score != -1) {
+                        sender.sendMessage(Utils.translate("&c" + a[2] + " &7has a &c" + StringUtils.capitalize(type.toString().toLowerCase()) + " &7score of &6" + Utils.formatNumber(score)));
+                    }
+                    else {
+                        sender.sendMessage(Utils.translate("&4" + a[2] + " &ccould not be found"));
+                    }
                 }
                 // self
             } else if (a.length == 2) {

--- a/src/main/java/com/renatusnetwork/momentum/commands/SquadsCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/SquadsCMD.java
@@ -134,7 +134,7 @@ public class SquadsCMD implements CommandExecutor {
 					SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName() + " &bhas left the squad");
 					player.sendMessage(Utils.translate("&3You have left the squad"));
 					if (squad.size() <= 1) {
-						SquadsManager.notifyMembers(squad, "&3The squad has been disbanded because all players left");
+						SquadsManager.notifyMembers(squad, "&3The squad has been disbanded because no members remain");
 						squadsManager.disband(squad);
 					} else if (leader) {
 						PlayerStats newLeader = squadsManager.getOldestMember(squad, player);
@@ -161,6 +161,11 @@ public class SquadsCMD implements CommandExecutor {
 						squadsManager.kick(targetMember);
 						SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName()  + " &bhas kicked &3" + targetMember.getDisplayName() + " &bfrom the squad");
 						targetMember.sendMessage(Utils.translate("&3You have been kicked from the squad"));
+
+						if (squad.size() <= 1 && !squadsManager.hasOfflineCache(squad)) {
+							SquadsManager.notifyMembers(squad, "&3The squad has been disbanded because no members remain");
+							squadsManager.disband(squad);
+						}
 					}
 				}
 

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTier.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTier.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
 
-public class ELOTier implements Comparable<ELOTier> {
+public class ELOTier {
 
     private String name;
     private String title;
@@ -64,11 +64,5 @@ public class ELOTier implements Comparable<ELOTier> {
 
     public void setPreviousELOTier(String previousELOTier) {
         this.previousELOTier = previousELOTier;
-    }
-
-    // will return <0 if this tier comes before the argument tier
-    @Override
-    public int compareTo(@NotNull ELOTier tier) {
-        return Integer.compare(this.requiredELO, tier.requiredELO);
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTier.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTier.java
@@ -2,8 +2,11 @@ package com.renatusnetwork.momentum.data.elo;
 
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.utils.Utils;
+import org.jetbrains.annotations.NotNull;
 
-public class ELOTier {
+import java.util.Objects;
+
+public class ELOTier implements Comparable<ELOTier> {
 
     private String name;
     private String title;
@@ -61,5 +64,11 @@ public class ELOTier {
 
     public void setPreviousELOTier(String previousELOTier) {
         this.previousELOTier = previousELOTier;
+    }
+
+    // will return <0 if this tier comes before the argument tier
+    @Override
+    public int compareTo(@NotNull ELOTier tier) {
+        return Integer.compare(this.requiredELO, tier.requiredELO);
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
@@ -1,18 +1,28 @@
 package com.renatusnetwork.momentum.data.elo;
 
-import java.util.HashMap;
+import java.util.*;
 
 public class ELOTiersManager {
 
+    private List<ELOTier> orderedTiers;
     private HashMap<String, ELOTier> tiers;
 
     public ELOTiersManager() {
         this.tiers = ELOTierDB.getTiers();
+        this.orderedTiers = new ArrayList<>(tiers.values());
+        Collections.sort(this.orderedTiers);
     }
 
     public void create(String name) {
-        tiers.put(name, new ELOTier(name));
+        ELOTier tier = new ELOTier(name);
+        tiers.put(name, tier);
+        orderedTiers.add(tier);
+        Collections.sort(orderedTiers);
         ELOTierDB.create(name);
+    }
+
+    public List<ELOTier> getAll() {
+        return orderedTiers;
     }
 
     public ELOTier get(String name) {
@@ -26,6 +36,7 @@ public class ELOTiersManager {
 
     public void updateRequiredELO(ELOTier tier, int requiredELO) {
         tier.setRequiredELO(requiredELO);
+        Collections.sort(orderedTiers);
         ELOTierDB.updateRequiredELO(tier.getName(), requiredELO);
     }
 
@@ -37,5 +48,25 @@ public class ELOTiersManager {
     public void updatePreviousELOTier(ELOTier tier, String previousELOTier) {
         tier.setPreviousELOTier(previousELOTier);
         ELOTierDB.updatePreviousTier(tier.getName(), previousELOTier);
+    }
+
+    // one pitfall is this assumes that elo tiers are linked in the same order as if their required elo's are in ascending order
+    // there's no reason for them not to be the same, but it is an assumption to mention
+    public ELOTier calculateELOTierDirectly(int elo) {
+        // simple binary search since elo tiers are sorted by required elo
+        ELOTier dummyTier = new ELOTier("");
+        dummyTier.setRequiredELO(elo);
+
+        int i = Arrays.binarySearch(orderedTiers.toArray(new ELOTier[0]), dummyTier);
+
+        if (i >= 0) {
+            return orderedTiers.get(i);
+        }
+
+        // if there is no exact match, Arrays#binarySearch returns `-(insertionPoint) - 1`
+        // so to get the element before the insertion point (the floor index),
+        // just solve for the insertion point and subtract 1 yielding `-i - 2`
+        int floorIndex = Math.max(0, -i - 2); // if the floor index is less than 0, then an elo less than the first elo tier was supplied
+        return orderedTiers.get(floorIndex);
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
@@ -1,28 +1,20 @@
 package com.renatusnetwork.momentum.data.elo;
 
+import com.renatusnetwork.momentum.Momentum;
+
 import java.util.*;
 
 public class ELOTiersManager {
 
-    private List<ELOTier> orderedTiers;
     private HashMap<String, ELOTier> tiers;
 
     public ELOTiersManager() {
         this.tiers = ELOTierDB.getTiers();
-        this.orderedTiers = new ArrayList<>(tiers.values());
-        Collections.sort(this.orderedTiers);
     }
 
     public void create(String name) {
-        ELOTier tier = new ELOTier(name);
-        tiers.put(name, tier);
-        orderedTiers.add(tier);
-        Collections.sort(orderedTiers);
+        tiers.put(name, new ELOTier(name));
         ELOTierDB.create(name);
-    }
-
-    public List<ELOTier> getAll() {
-        return orderedTiers;
     }
 
     public ELOTier get(String name) {
@@ -36,7 +28,6 @@ public class ELOTiersManager {
 
     public void updateRequiredELO(ELOTier tier, int requiredELO) {
         tier.setRequiredELO(requiredELO);
-        Collections.sort(orderedTiers);
         ELOTierDB.updateRequiredELO(tier.getName(), requiredELO);
     }
 
@@ -50,23 +41,26 @@ public class ELOTiersManager {
         ELOTierDB.updatePreviousTier(tier.getName(), previousELOTier);
     }
 
-    // one pitfall is this assumes that elo tiers are linked in the same order as if their required elo's are in ascending order
-    // there's no reason for them not to be the same, but it is an assumption to mention
     public ELOTier calculateELOTierDirectly(int elo) {
-        // simple binary search since elo tiers are sorted by required elo
-        ELOTier dummyTier = new ELOTier("");
-        dummyTier.setRequiredELO(elo);
+        ELOTier tier = tiers.get(Momentum.getSettingsManager().default_elo_tier);
+        ELOTier next = tier.getNextELOTier();
 
-        int i = Arrays.binarySearch(orderedTiers.toArray(new ELOTier[0]), dummyTier);
-
-        if (i >= 0) {
-            return orderedTiers.get(i);
+        // if for some reason the argument elo is lower than the lowest tier
+        if (elo <= tier.getRequiredELO()) {
+            return tier;
         }
 
-        // if there is no exact match, Arrays#binarySearch returns `-(insertionPoint) - 1`
-        // so to get the element before the insertion point (the floor index),
-        // just solve for the insertion point and subtract 1 yielding `-i - 2`
-        int floorIndex = Math.max(0, -i - 2); // if the floor index is less than 0, then an elo less than the first elo tier was supplied
-        return orderedTiers.get(floorIndex);
+        while (next != null) {
+            if (elo >= tier.getRequiredELO() && elo < next.getRequiredELO()) {
+                return tier;
+            }
+
+            tier = next;
+            next = tier.getNextELOTier();
+        }
+
+        // argument is higher than the highest tier
+        // or lower than the lowest tier
+        return tier;
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/infinite/InfiniteManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/infinite/InfiniteManager.java
@@ -369,6 +369,15 @@ public class InfiniteManager {
         return null;
     }
 
+    public InfiniteType getType(String type) {
+        try {
+            return InfiniteType.valueOf(type);
+        }
+        catch (IllegalArgumentException iae) {
+            return null;
+        }
+    }
+
     public void loadLeaderboards() {
         for (InfiniteLB lb : leaderboards.values()) {
             lb.loadLeaderboard();

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsDB.java
@@ -359,6 +359,33 @@ public class StatsDB {
         return !playerResult.isEmpty() ? Integer.parseInt(playerResult.get("coins")) : 0;
     }
 
+    public static int getPlayerInfiniteHighscore(String playerName, InfiniteType type) {
+        String infiniteQuery = "";
+
+        switch (type) {
+            case CLASSIC:
+                infiniteQuery = "infinite_classic_score";
+                break;
+            case SPEEDRUN:
+                infiniteQuery = "infinite_speedrun_score";
+                break;
+            case SPRINT:
+                infiniteQuery = "infinite_sprint_score";
+                break;
+            case TIMED:
+                infiniteQuery = "infinite_timed_score";
+                break;
+        }
+
+        Map<String, String> playerResult = DatabaseQueries.getResult(
+                DatabaseManager.PLAYERS_TABLE,
+                infiniteQuery,
+                " WHERE name=?", playerName
+        );
+
+        return !playerResult.isEmpty() ? Integer.parseInt(playerResult.get(infiniteQuery)) : -1;
+    }
+
     public static boolean isPlayerInDatabase(String playerName) {
         Map<String, String> playerResult = DatabaseQueries.getResult(
                 DatabaseManager.PLAYERS_TABLE,

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -191,7 +191,7 @@ public class StatsManager {
     }
 
     public PlayerStats get(Player player) {
-        return playerStatsUUID.get(player.getUniqueId().toString());
+        return player != null ? playerStatsUUID.get(player.getUniqueId().toString()) : null;
     }
 
     public PlayerStats get(String uuid) {

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/JoinLeaveListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/JoinLeaveListener.java
@@ -208,7 +208,7 @@ public class JoinLeaveListener implements Listener {
             if (squad.size() == 0) { // everyone leaves
                 squadsManager.disband(squad);
             } else {
-                SquadsManager.notifyMembers(squad, "&9SC &3" + playerStats.getDisplayName() + " &bhas disconnected! They have one minute to rejoin or they'll be removed from the squad");
+                SquadsManager.notifyMembers(squad, "&9SC &3" + playerStats.getDisplayName() + " &bhas disconnected! They have one minute to rejoin, or they'll be removed from the squad");
                 new BukkitRunnable() {
                     @Override
                     public void run() {
@@ -216,7 +216,7 @@ public class JoinLeaveListener implements Listener {
                         if (squadsManager.getOffline(playerStats.getUUID()) != null) {
                             squadsManager.removeOffline(playerStats.getUUID());
                             if (squad.size() <= 1 && !squadsManager.hasOfflineCache(squad)) {
-                                SquadsManager.notifyMembers(squad, "&3The squad has been disbanded because all players left");
+                                SquadsManager.notifyMembers(squad, "&3The squad has been disbanded because no members remain");
                                 squadsManager.disband(squad);
                             } else {
                                 if (leader) {


### PR DESCRIPTION
**Changelog**:
- Added infinite type checking to avoid throwing an `IllegalArgumentException`
- Fixed squad disband logic
- Created command to view an offline player's infinite high score
- Created command to quit infinite prematurely
- Created command to list ELO tiers
- Synced ELO and ELO tier modifications with each other

Full testing document can be found [here](https://docs.google.com/document/d/1yllh91fjpgdEFmfPDLaC1W4fwNtzINid1inUeoDGtV8/edit?usp=sharing)

For ELO and ELO tiers, each corresponding modification command (i.e. `/elo set <player>` and `/elotier set <player> <tier>`) doesn't update the other. ELO didn't update with ELO tiers and ELO tiers didn't update with ELO (only when modified through the command). The solution I decided was best was to keep an ordered list of the tiers upon load and modification. It's a sacrifice in time on startup and modification to avoid wasting time retrieving and updating ELO tiers. If it isn't deemed necessary that ELO and ELO tiers should update together, and that any staff executing the command has the responsibility to update them independently, then this feature isn't really necessary at all. It's a QOL feature for staff members since the ELO tier command is staff only, and it's very easy to forget to update one or the other alongside each other.