### PR TITLE
Users/anxiety/small tweaks

### DIFF
--- a/src/main/java/com/renatusnetwork/momentum/Momentum.java
+++ b/src/main/java/com/renatusnetwork/momentum/Momentum.java
@@ -184,6 +184,7 @@ public class Momentum extends JavaPlugin {
         getCommand("elotier").setExecutor(new ELOTierCMD());
         getCommand("commandsign").setExecutor(new CommandSignCMD());
         getCommand("squads").setExecutor(new SquadsCMD());
+        getCommand("reset").setExecutor(new ResetCMD());
     }
 
     private static void load() {

--- a/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/CommandSignCMD.java
@@ -1,9 +1,11 @@
 package com.renatusnetwork.momentum.commands;
 
 import com.renatusnetwork.momentum.Momentum;
+import com.renatusnetwork.momentum.data.SettingsManager;
 import com.renatusnetwork.momentum.data.cmdsigns.CmdSignLocation;
 import com.renatusnetwork.momentum.data.cmdsigns.CommandSign;
 import com.renatusnetwork.momentum.data.cmdsigns.CommandSignManager;
+import com.renatusnetwork.momentum.storage.mysql.DatabaseQueries;
 import com.renatusnetwork.momentum.utils.Utils;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -18,6 +20,11 @@ public class CommandSignCMD implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] a) {
+        if (!sender.isOp()) {
+            sender.sendMessage(Utils.translate("&cInsufficient permissions"));
+            return true;
+        }
+
         if (a.length == 1) {
             if (a[0].equalsIgnoreCase("list")) {
                 showList(sender);
@@ -27,10 +34,6 @@ public class CommandSignCMD implements CommandExecutor {
             return true;
         }
 
-        if (!sender.isOp()) {
-            sender.sendMessage(Utils.translate("&cInsufficient permissions"));
-            return true;
-        }
         if (a.length < 2) {
             sendHelp(sender);
             return true;
@@ -71,18 +74,19 @@ public class CommandSignCMD implements CommandExecutor {
                 } else if (csignManager.commandSignExists(new CmdSignLocation(player.getWorld(), x, y, z))) {
                     sender.sendMessage(Utils.translate("&cCommand sign already exists at that location"));
                 } else {
-                    cmd = String.join(" ", Arrays.copyOfRange(a, 5, a.length));
-                    csignManager.addCommandSign(name, cmd.isEmpty() ? null : cmd, player.getWorld(), x, y, z);
-                    sender.sendMessage(Utils.translate("&aSuccessfully created command sign at (" + x + ", " + y + ", " + z + ")"));
+                    csignManager.addCommandSign(name, player.getWorld(), x, y, z);
+                    sender.sendMessage(Utils.translate("&aSuccessfully created command sign at &2(" + x + ", " + y + ", " + z + ")"));
                 }
+
                 break;
             case "delete":
                 if (!csignManager.commandSignExists(name)) {
-                    sender.sendMessage(Utils.translate("&cCommand sign does not exist with that name"));
+                    sender.sendMessage(Utils.translate("&cCommand sign &4" + name + " &cdoes not exist"));
                 } else {
                     csignManager.deleteCommandSign(name);
                     sender.sendMessage(Utils.translate("&aSuccessfully deleted command sign &2" + name));
                 }
+
                 break;
             case "modify":
                 if (a.length < 3) {
@@ -115,6 +119,7 @@ public class CommandSignCMD implements CommandExecutor {
 
                 result = csignManager.updateCommand(name, index, cmd);
                 sender.sendMessage(Utils.translate(result ? "&aSuccessfully updated command at index &2" + (index + 1) + " &afor &2" + name : Utils.translate("&cIndex &4" + (index + 1) + " &cdoes not exist for &4" + name)));
+
                 break;
             case "broadcast":
                 if (!csignManager.commandSignExists(name)) {
@@ -122,7 +127,8 @@ public class CommandSignCMD implements CommandExecutor {
                     return true;
                 }
                 csignManager.toggleBroadcast(name);
-                sender.sendMessage(Utils.translate("&7Toggled broadcast of &a" + name + "&7 to " + (csignManager.getCommandSign(name).isBroadcast() ? "&atrue" : "&cfalse")));
+                sender.sendMessage(Utils.translate("&7Toggled broadcast of &2" + name + "&7 to " + (csignManager.getCommandSign(name).isBroadcast() ? "&atrue" : "&cfalse")));
+
                 break;
             case "title":
                 if (!csignManager.commandSignExists(name)) {
@@ -133,6 +139,7 @@ public class CommandSignCMD implements CommandExecutor {
                 String title = String.join(" ", Arrays.copyOfRange(a, 2, a.length));
                 csignManager.updateTitle(name, title);
                 sender.sendMessage(Utils.translate("&7Set title for &2" + name + "&7 to &a" + title));
+
                 break;
             case "show":
                 if (!csignManager.commandSignExists(name)) {
@@ -142,6 +149,7 @@ public class CommandSignCMD implements CommandExecutor {
 
                 CommandSign csign = csignManager.getCommandSign(name);
                 showInfo(sender, csign);
+
                 break;
             case "add":
                 if (!csignManager.commandSignExists(name)) {
@@ -162,6 +170,7 @@ public class CommandSignCMD implements CommandExecutor {
 
                 csignManager.addCommand(name, cmd);
                 sender.sendMessage(Utils.translate("&aSuccessfully added command to &2" + name));
+
                 break;
             case "remove":
                 if (a.length < 3) {
@@ -189,9 +198,11 @@ public class CommandSignCMD implements CommandExecutor {
 
                 result = csignManager.removeCommand(name, index);
                 sender.sendMessage(Utils.translate(result ? "&aSuccessfully removed command at index &2" + (index + 1) + " &afor &2" + name : Utils.translate("&cindex &4" + (index + 1) + " &cdoes not exist for &4" + name)));
+
                 break;
             default:
                 sendHelp(sender);
+
                 break;
         }
 
@@ -203,9 +214,8 @@ public class CommandSignCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/commandsign help  &7Displays this menu"));
         sender.sendMessage(Utils.translate("&a/commandsign list  &7Shows list of all command signs"));
         sender.sendMessage(Utils.translate("&a/commandsign show <name>  &7Displays details of a command sign"));
-        sender.sendMessage(Utils.translate("&a/commandsign create <name> <x> <y> <z> [command]  &7Creates uniquely named command sign at supplied integer coordinates"));
-        sender.sendMessage(Utils.translate("    &2&ooptional &2[command]  &7aAdds the singular command to the created command sign"));
-        sender.sendMessage(Utils.translate("&a/commandsign delete <name> &7Deletes the specified command sign"));
+        sender.sendMessage(Utils.translate("&a/commandsign create <name> <x> <y> <z>  &7Creates a uniquely named command sign at supplied integer coordinates"));
+        sender.sendMessage(Utils.translate("&a/commandsign delete <name>  &7Deletes the specified command sign"));
         sender.sendMessage(Utils.translate("&a/commandsign modify <name> <index> <command>  &7Updates a sign's command at the specified index"));
         sender.sendMessage(Utils.translate("&a/commandsign add <name> <command>  &7Adds a command to the command sign"));
         sender.sendMessage(Utils.translate("&a/commandsign remove <name> <index|all>  &7Removes the command at the specified index, or all commands, from the command sign"));
@@ -213,14 +223,21 @@ public class CommandSignCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/commandsign title <name> <title>  &7Sets sign title"));
     }
 
+    // maybe add pages in the future
     private static void showList(CommandSender sender) {
+        Collection<CommandSign> csigns = Momentum.getCommandSignManager().getCommandSigns();
+
+        if (csigns.isEmpty()) {
+            sender.sendMessage(Utils.translate("&cThere are currently no command signs"));
+            return;
+        }
+
         sender.sendMessage(Utils.translate("&7Command Signs"));
 
-        Collection<CommandSign> csigns = Momentum.getCommandSignManager().getCommandSigns();
         for (CommandSign csign : csigns) {
             CmdSignLocation loc = csign.getLocation();
             List<String> cmds = csign.getCommands();
-            sender.sendMessage(Utils.translate("&a" + csign.getName() + ": " + loc.toString()));
+            sender.sendMessage(Utils.translate("&2" + csign.getName() + "&7: &a" + loc.toString()));
             sender.sendMessage(Utils.translate("  &7Command(s):"));
             for (int i = 0; i < cmds.size(); i++) {
                 sender.sendMessage(Utils.translate("    &2&o" + (i + 1) + ". /") + cmds.get(i));

--- a/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ELOTierCMD.java
@@ -35,6 +35,18 @@ public class ELOTierCMD implements CommandExecutor {
                 } else {
                     sender.sendMessage(Utils.translate("&4" + name + " &calready exists"));
                 }
+            } else if (a.length == 2 && a[0].equalsIgnoreCase("delete")) {
+                String name = a[1].toLowerCase();
+
+                ELOTier tier = Momentum.getELOTiersManager().get(name);
+                if (tier == null) {
+                    sender.sendMessage(Utils.translate("&cELO tier &4" + name + " &cdoes not exist"));
+                } else if (name.equalsIgnoreCase(Momentum.getSettingsManager().default_elo_tier)) {
+                    sender.sendMessage(Utils.translate("&cCannot delete the default ELO tier. Change it in config before deleting it."));
+                } else {
+                    Momentum.getELOTiersManager().deleteELOTier(tier);
+                    sender.sendMessage(Utils.translate("&aSuccessfully removed &2" + name));
+                }
             } else if (a.length == 1 && a[0].equalsIgnoreCase("list")) {
                 sendELOTiers(sender);
             } else if (a.length == 2 && a[0].equalsIgnoreCase("tier")) {
@@ -136,18 +148,19 @@ public class ELOTierCMD implements CommandExecutor {
         ELOTier next = tier.getNextELOTier();
 
         while (next != null) {
-            sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")  &7->  " + next.getFormattedTitle()));
+            sender.sendMessage(Utils.translate("&a- &7&o" + tier.getName() + "  " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")  &7->  " + next.getFormattedTitle()));
 
             tier = next;
             next = tier.getNextELOTier();
         }
 
-        sender.sendMessage(Utils.translate("&a- " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")"));
+        sender.sendMessage(Utils.translate("&a- &7&o" + tier.getName() + "  " + tier.getFormattedTitle() + " &a(" + tier.getRequiredELO() + ")"));
     }
 
     private void sendHelp(CommandSender sender) {
         sender.sendMessage(Utils.translate("&2&lELO Tier Help"));
         sender.sendMessage(Utils.translate("&a/elotier create (name)  &7Creates an ELO tier"));
+        sender.sendMessage(Utils.translate("&a/elotier delete (name)  &7Deletes an ELO tier"));
         sender.sendMessage(Utils.translate("&a/elotier title (name) (title)  &7Sets a tier's title"));
         sender.sendMessage(Utils.translate("&a/elotier requiredelo (name) (requiredELO)  &7Sets a tier's required ELO"));
         sender.sendMessage(Utils.translate("&a/elotier next (name) (nextTier)  &7Sets a tier's next name"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
@@ -721,15 +721,6 @@ public class LevelCMD implements CommandExecutor {
                             "&7You have set the new level value of &c" + level.getTitle() + "&7 to &c" + level.isNew()
                     ));
                 }
-            } else if (a.length == 2 && a[0].equalsIgnoreCase("legacy")) {
-                Level level = getLevel(sender, a[1].toLowerCase());
-
-                if (level != null) {
-                    levelManager.toggleLegacy(level);
-                    sender.sendMessage(Utils.translate(
-                            "&7You have set the legacy level value of &c" + level.getTitle() + "&7 to &c" + level.isLegacy()
-                    ));
-                }
             } else if (a.length == 3 && a[0].equalsIgnoreCase("difficulty")) {
                 Level level = getLevel(sender, a[1].toLowerCase());
 

--- a/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
@@ -337,6 +337,68 @@ public class LevelCMD implements CommandExecutor {
                 } else {
                     sender.sendMessage(Utils.translate("&c" + a[2] + " &7is not an integer!"));
                 }
+            } else if (a.length == 3 && a[0].equalsIgnoreCase("delcompletions")) {
+                String playerName = a[1].toLowerCase();
+                String levelName = a[2].toLowerCase();
+                Level level = getLevel(sender, levelName);
+
+                String player_uuid = StatsDB.getUUIDByName(playerName);
+
+                if (player_uuid == null) {
+                    sender.sendMessage(Utils.translate("&cPlayer &4" + playerName + " &cnot found"));
+                    return true;
+                }
+
+                if (level != null) {
+                    List<LevelLBPosition> lb = level.getLeaderboard();
+                    int completions = CompletionsDB.getPlayerLevelCompletionsCount(player_uuid, level.getName());
+
+                    // run it in async!
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            CompletionsDB.removeCompletions(player_uuid, level.getName());
+
+                            level.setTotalCompletionsCount(level.getTotalCompletionsCount() - completions);
+                            level.setLeaderboard(CompletionsDB.getLeaderboard(levelName));
+                            levelManager.removeTotalLevelCompletion(completions);
+
+                            // if deleting record
+                            if (lb.get(0).getPlayerName().equalsIgnoreCase(playerName)) {
+                                List<LevelLBPosition> newLeaderboard = level.getLeaderboard();
+
+                                if (!newLeaderboard.isEmpty()) {
+                                    // if the new leaderboard is no longer empty, add record for new holder
+                                    LevelLBPosition newHolder = newLeaderboard.get(0);
+
+                                    // if it is a diff person, need to update their in game stats
+                                    if (!playerName.equalsIgnoreCase(newHolder.getPlayerName())) {
+                                        PlayerStats oldHolderStats = statsManager.get(player_uuid);
+                                        PlayerStats newHolderStats = statsManager.getByName(newHolder.getPlayerName());
+
+                                        if (oldHolderStats != null) {
+                                            oldHolderStats.removeRecord(level);
+                                        }
+
+                                        if (newHolderStats != null) {
+                                            newHolderStats.addRecord(level, newHolder.getTimeTaken());
+                                        }
+                                    }
+                                }
+                            }
+
+                            PlayerStats targetStats = Momentum.getStatsManager().get(player_uuid);
+
+                            if (targetStats != null) {
+                                targetStats.removeCompletions(level.getName());
+                            }
+
+                            sender.sendMessage(Utils.translate("&4" + playerName + "'s &ccompletions have been removed succesfully from &4" + levelName));
+                        }
+                    }.runTaskAsynchronously(Momentum.getPlugin());
+                } else {
+                    sender.sendMessage(Utils.translate("&c" + a[2] + " is not a level"));
+                }
             } else if (a.length == 3 && a[0].equalsIgnoreCase("respawny")) {
                 if (Utils.isInteger(a[2])) {
                     // get new y

--- a/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
@@ -705,7 +705,7 @@ public class LevelCMD implements CommandExecutor {
 
                 if (level != null) {
                     levelManager.toggleTC(level);
-                    sender.sendMessage(Utils.translate("&7You have turned " + level.getTitle() + "&7's cooldown toggle to &2" + level.isTCEnabled()));
+                    sender.sendMessage(Utils.translate("&7You have toggled TC for &c" + level.getTitle() + "&7 to &c" + level.isTCEnabled()));
                 }
             } else if (a.length == 1 && a[0].equalsIgnoreCase("pickfeatured")) {
                 levelManager.pickFeatured();

--- a/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
@@ -925,6 +925,7 @@ public class LevelCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&a/level addboughtlevel <player> <level>  &7Add bought level to player"));
         sender.sendMessage(Utils.translate("&a/level removeboughtlevel <player> <level>  &7Remove bought level from player"));
         sender.sendMessage(Utils.translate("&a/level new <level>  &7Toggles if the level is new (for menu and future updates)"));
+        sender.sendMessage(Utils.translate("&a/level legacy <level>  &7Toggles if the level is legacy (for menu and future updates)"));
         sender.sendMessage(Utils.translate("&a/level difficulty <level> <difficulty>  &7Sets the difficulty of the level"));
         sender.sendMessage(Utils.translate("&a/level cooldown <level>  &7Toggles if the level has a cooldown"));
         sender.sendMessage(Utils.translate("&a/level tc <level>  &7Toggles if the level uses TC blocks"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/LevelCMD.java
@@ -659,6 +659,15 @@ public class LevelCMD implements CommandExecutor {
                             "&7You have set the new level value of &c" + level.getTitle() + "&7 to &c" + level.isNew()
                     ));
                 }
+            } else if (a.length == 2 && a[0].equalsIgnoreCase("legacy")) {
+                Level level = getLevel(sender, a[1].toLowerCase());
+
+                if (level != null) {
+                    levelManager.toggleLegacy(level);
+                    sender.sendMessage(Utils.translate(
+                            "&7You have set the legacy level value of &c" + level.getTitle() + "&7 to &c" + level.isLegacy()
+                    ));
+                }
             } else if (a.length == 3 && a[0].equalsIgnoreCase("difficulty")) {
                 Level level = getLevel(sender, a[1].toLowerCase());
 

--- a/src/main/java/com/renatusnetwork/momentum/commands/PerksCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/PerksCMD.java
@@ -252,7 +252,7 @@ public class PerksCMD implements CommandExecutor {
                     if (type != null) {
                         // we can only update it if it exists
                         if (perk.hasArmorItem(type)) {
-                            boolean glow = perkManager.updateArmorGlow(perk, type); // get the result of the glow toggle for printing
+                            boolean glow = perkManager.toggleArmorGlow(perk, type); // get the result of the glow toggle for printing
                             sender.sendMessage(Utils.translate(
                                     "&7You have updated &c" + perkName + "&7's armor piece &c" + type.name() + "&7's glow to &c" + glow
                             ));

--- a/src/main/java/com/renatusnetwork/momentum/commands/PerksCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/PerksCMD.java
@@ -501,7 +501,7 @@ public class PerksCMD implements CommandExecutor {
         sender.sendMessage(Utils.translate("&e/perks requiredelotier (perkName) (eloTier)  &7Sets the required ELO tier for the perk"));
         sender.sendMessage(Utils.translate("&e/perks addcommand (perkName) (command)  &7Adds a command to a perk to give out on setting (command can be multiple words)"));
         sender.sendMessage(Utils.translate("&e/perks removecommand (perkName) (command)  &7Removes a command to a perk to give out on setting (command can be multiple words)"));
-        sender.sendMessage(Utils.translate("&e/perks commands (perkName)  &7Lists the commands for a perka"));
+        sender.sendMessage(Utils.translate("&e/perks commands (perkName)  &7Lists the commands for a perk"));
         sender.sendMessage(Utils.translate("&e/perks help  &7Displays this page"));
         sender.sendMessage(Utils.translate("&e/perks load  &7Loads from db"));
     }

--- a/src/main/java/com/renatusnetwork/momentum/commands/PlotCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/PlotCMD.java
@@ -495,7 +495,6 @@ public class PlotCMD implements CommandExecutor {
     private static void sendHelp(CommandSender sender) {
         sender.sendMessage(Utils.translate("&2&lPlots Help"));
         sender.sendMessage(Utils.translate("&a/plot create  &7Automatically create a plot"));
-        sender.sendMessage(Utils.translate("&a/plot delete  &7Deletes your plot (confirm needed)"));
         sender.sendMessage(Utils.translate("&a/plot clear  &7Clears your plot but does not delete it"));
         sender.sendMessage(Utils.translate("&a/plot home  &7Teleports you to your plot"));
         sender.sendMessage(Utils.translate("&a/plot visit <player>  &7Visit another player's plot"));

--- a/src/main/java/com/renatusnetwork/momentum/commands/PlotCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/PlotCMD.java
@@ -23,7 +23,7 @@ public class PlotCMD implements CommandExecutor {
 
     private HashMap<String, BukkitTask> deletePlotConfirm = new HashMap<>();
     private HashMap<String, BukkitTask> acceptPlotConfirm = new HashMap<>();
-    private HashMap<String, BukkitTask> wipePlotsConfirm = new HashMap<>();
+    // private HashMap<String, BukkitTask> wipePlotsConfirm = new HashMap<>();
 
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] a) {

--- a/src/main/java/com/renatusnetwork/momentum/commands/ResetCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/ResetCMD.java
@@ -1,0 +1,270 @@
+package com.renatusnetwork.momentum.commands;
+
+import com.renatusnetwork.momentum.Momentum;
+import com.renatusnetwork.momentum.data.checkpoints.CheckpointDB;
+import com.renatusnetwork.momentum.data.cmdsigns.CmdSignsDB;
+import com.renatusnetwork.momentum.data.infinite.gamemode.InfiniteType;
+import com.renatusnetwork.momentum.data.levels.CompletionsDB;
+import com.renatusnetwork.momentum.data.levels.LevelsDB;
+import com.renatusnetwork.momentum.data.ranks.RanksDB;
+import com.renatusnetwork.momentum.data.saves.SavesDB;
+import com.renatusnetwork.momentum.data.stats.StatsDB;
+import com.renatusnetwork.momentum.utils.Utils;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ResetCMD implements CommandExecutor {
+    /*
+     * /reset <player> <stat>
+     * possible stats to reset:
+     * - ALL (resets EVERYTHING)
+     * - coins
+     * - records (timed completions)
+     * - completions (by extension resets records)
+     * - saves & checkpoints
+     * - rank (non-donor rank)
+     * - clan stats
+     * - purchased levels
+     * - ingame stats (total jumps, infinite highscore, etc.)
+     * - modifiers
+     * - elo
+     */
+
+    private final Map<ResetInfo, BukkitTask> resetConfirmMap = new HashMap<>();
+    private static final Map<ResettableStat, Resetter> statResetters = new HashMap<>();
+
+    static {
+        statResetters.put(ResettableStat.ALL, playerUUID -> {
+            resetCoins(playerUUID);
+            resetAllCompletions(playerUUID);
+            resetSavesAndCheckpoints(playerUUID);
+            resetParkourRank(playerUUID);
+            resetClanMembership(playerUUID);
+            resetPurchasedLevels(playerUUID);
+            resetInGameStats(playerUUID);
+            resetModifiers(playerUUID);
+            resetELO(playerUUID);
+            resetUsedCommandSigns(playerUUID);
+        });
+
+        statResetters.put(ResettableStat.COINS, ResetCMD::resetCoins);
+        statResetters.put(ResettableStat.TIMED_COMPLETIONS, ResetCMD::resetTimedCompletions);
+        statResetters.put(ResettableStat.ALL_COMPLETIONS, ResetCMD::resetAllCompletions);
+        statResetters.put(ResettableStat.SAVES_AND_CHECKPOINTS, ResetCMD::resetSavesAndCheckpoints);
+        statResetters.put(ResettableStat.PARKOUR_RANK, ResetCMD::resetParkourRank);
+        statResetters.put(ResettableStat.CLAN_MEMBERSHIP, ResetCMD::resetClanMembership);
+        statResetters.put(ResettableStat.PURCHASED_LEVELS, ResetCMD::resetPurchasedLevels);
+        statResetters.put(ResettableStat.INGAME_STATS, ResetCMD::resetInGameStats);
+        statResetters.put(ResettableStat.MODIFIERS, ResetCMD::resetModifiers);
+        statResetters.put(ResettableStat.ELO, ResetCMD::resetELO);
+        statResetters.put(ResettableStat.USED_COMMAND_SIGNS, ResetCMD::resetUsedCommandSigns);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.isOp()) {
+            sender.sendMessage(Utils.translate("&cInsufficient permissions"));
+            return true;
+        }
+
+        if (args.length != 2) {
+            sendHelp(sender);
+            return true;
+        }
+
+        String playerName = args[0].toLowerCase();
+        String stat = args[1];
+        String playerUUID = StatsDB.getUUIDByName(playerName);
+
+        if (Momentum.getStatsManager().get(playerUUID) != null) {
+            sender.sendMessage(Utils.translate("&cYou can only reset the stats of an offline player"));
+            return true;
+        }
+
+        if (playerUUID == null) {
+            sender.sendMessage(Utils.translate(String.format("&cPlayer &4%s &cwas not found", playerName)));
+            return true;
+        }
+
+        if (Momentum.getStatsManager().getOffline(playerUUID) != null) {
+            Momentum.getStatsManager().removeOffline(playerUUID);
+        }
+
+        ResettableStat statToReset;
+
+        try {
+            statToReset = ResettableStat.valueOf(stat.toUpperCase());
+        } catch (IllegalArgumentException iae) {
+            sender.sendMessage(Utils.translate(String.format("&cPlayer stat &4%s &cis not a valid stat", stat)));
+            return true;
+        }
+
+        if (!confirm(sender, playerUUID, playerName, statToReset)) {
+            sender.sendMessage(Utils.translate(String.format("&6Are you sure you want to reset stat &4%s &6for player &4%s&6? Type the command again to confirm.", statToReset.name(), playerName)));
+            return true;
+        }
+
+        statResetters.get(statToReset).execute(playerUUID);
+
+        sender.sendMessage(Utils.translate(String.format("&aSuccessfuly reset stat &2%s &afor player &2%s", statToReset.name(), playerName)));
+
+        return true;
+    }
+
+    public enum ResettableStat {
+        ALL("Resets ALL stats for a player"),
+        COINS("Sets a player's coins to 0"),
+        TIMED_COMPLETIONS("Resets all timed level completions for a player"),
+        ALL_COMPLETIONS("Resets all level completions for a player"),
+        SAVES_AND_CHECKPOINTS("Resets all saves and checkpoints within all levels for a player"),
+        PARKOUR_RANK("Sets the rank of a player to " + Momentum.getRanksManager().get(Momentum.getSettingsManager().default_rank).getTitle()),
+        CLAN_MEMBERSHIP("Forcefully kicks a player from their clan"),
+        PURCHASED_LEVELS("Resets all purchased levels for a player"),
+        INGAME_STATS("Resets all in-game stats for a player"),
+        MODIFIERS("Resets all modifiers for a player"),
+        ELO("Sets the ELO of a player to " + Momentum.getSettingsManager().default_elo + ", and their ELO tier to " + Momentum.getELOTiersManager().get(Momentum.getSettingsManager().default_elo_tier).getTitle()),
+        USED_COMMAND_SIGNS("Resets all used command signs for a player");
+
+        final String description;
+
+        ResettableStat(String description) {
+            this.description = description;
+        }
+
+        public String getDescription() {
+            return this.description;
+        }
+    }
+
+    private void sendHelp(CommandSender sender) {
+        sender.sendMessage(Utils.translate(Utils.translate("&4&lReset Help")));
+
+        for (ResettableStat stat : ResettableStat.values()) {
+            sender.sendMessage(Utils.translate("&4/reset <player> " + stat.name() + "  &c" + stat.getDescription()));
+        }
+    }
+
+    private static void resetCoins(String playerUUID) {
+        StatsDB.updateCoins(playerUUID, 0, true);
+    }
+
+    private static void resetTimedCompletions(String playerUUID) {
+        CompletionsDB.removeAllCompletionsFromPlayer(playerUUID, true, true);
+    }
+
+    private static void resetAllCompletions(String playerUUID) {
+        CompletionsDB.removeAllCompletionsFromPlayer(playerUUID, false, true);
+    }
+
+    private static void resetSavesAndCheckpoints(String playerUUID) {
+        SavesDB.removeAllSavesFromPlayer(playerUUID);
+        CheckpointDB.deleteAllCheckpointsFromPlayer(playerUUID);
+    }
+
+    private static void resetParkourRank(String playerUUID) {
+        StatsDB.updateRank(playerUUID, Momentum.getSettingsManager().default_rank);
+    }
+
+    private static void resetClanMembership(String playerUUID) {
+        StatsDB.resetPlayerClanByUUID(playerUUID);
+    }
+
+    private static void resetPurchasedLevels(String playerUUID) {
+        StatsDB.removeAllBoughtLevels(playerUUID);
+    }
+
+    private static void resetInGameStats(String playerUUID) {
+        for (InfiniteType type : InfiniteType.values()) {
+            StatsDB.updateInfiniteScore(playerUUID, type, 0);
+        }
+
+        StatsDB.updateRaceLosses(playerUUID, 0);
+        StatsDB.updateRaceWins(playerUUID, 0);
+
+        StatsDB.updateEventWins(playerUUID, 0);
+
+        RanksDB.updatePrestiges(playerUUID, 0);
+
+        StatsDB.resetInfiniteBlock(playerUUID);
+
+        LevelsDB.removeAllLevelRatingsFromPlayer(playerUUID);
+
+        StatsDB.removeAllFavoriteLevels(playerUUID);
+    }
+
+    private static void resetModifiers(String playerUUID) {
+        StatsDB.removeAllModifiersFromPlayer(playerUUID);
+    }
+
+    private static void resetELO(String playerUUID) {
+        StatsDB.updateELO(playerUUID, Momentum.getSettingsManager().default_elo);
+        StatsDB.updateELOTier(playerUUID, Momentum.getSettingsManager().default_elo_tier);
+    }
+
+    private static void resetUsedCommandSigns(String playerUUID) {
+        CmdSignsDB.unuseAllCommandSigns(playerUUID);
+    }
+
+
+    private boolean confirm(CommandSender sender, String playerUUIDToReset, String playerNameToReset, ResettableStat statToReset) {
+        ResetInfo resetInfo = new ResetInfo(sender.getName(), playerUUIDToReset, statToReset);
+
+        BukkitTask task;
+        if ((task = resetConfirmMap.remove(resetInfo)) != null) {
+            task.cancel();
+            return true;
+        }
+
+        resetConfirmMap.put(resetInfo, new BukkitRunnable() {
+            @Override
+            public void run() {
+                resetConfirmMap.remove(resetInfo);
+                sender.sendMessage(Utils.translate(String.format("&cYou did not confirm in time to reset stat &4%s &cfor player &4%s", statToReset, playerNameToReset)));
+            }
+        }.runTaskLater(Momentum.getPlugin(), 20 * 3));
+
+        return false;
+    }
+
+    private static class ResetInfo {
+        public final String commandSender;
+        public final String playerUUIDToReset;
+        public final ResettableStat statToReset;
+
+        public ResetInfo(String commandSender, String playerUUIDToReset, ResettableStat statToReset) {
+            this.commandSender = commandSender;
+            this.playerUUIDToReset = playerUUIDToReset;
+            this.statToReset = statToReset;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            ResetInfo resetInfo;
+            if (!(other instanceof ResetInfo)) {
+                return false;
+            }
+
+            resetInfo = (ResetInfo) other;
+            return commandSender.equals(resetInfo.commandSender) &&
+                    playerUUIDToReset.equals(resetInfo.playerUUIDToReset) &&
+                    statToReset == resetInfo.statToReset;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(commandSender, playerUUIDToReset, statToReset);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Resetter {
+        void execute(String playerUUID);
+    }
+}

--- a/src/main/java/com/renatusnetwork/momentum/commands/SquadsCMD.java
+++ b/src/main/java/com/renatusnetwork/momentum/commands/SquadsCMD.java
@@ -33,17 +33,16 @@ public class SquadsCMD implements CommandExecutor {
 
 		int n = args.length;
 		if (label.equalsIgnoreCase("sqc")) {
-			if (!player.inSquad())
+			if (!player.inSquad()) {
 				sender.sendMessage(NO_SQUAD_MSG);
-			else if (n == 0)
+			} else if (n == 0) {
 				player.sendMessage(Utils.translate("&3You have toggled &9&lSquad Chat &b" + (squadsManager.toggleSquadChat(player) ? "on" : "off")));
-			else {
+			} else {
 				String msg = String.format("&9SC &3%s &b%s", player.getDisplayName(), String.join(" ", Arrays.copyOfRange(args, 0, n)));
 				squadsManager.sendMessage(player, msg, true);
 			}
 			return true;
-		}
-		else if (n == 0 || args[0].equalsIgnoreCase("help")) {
+		} else if (n == 0 || args[0].equalsIgnoreCase("help")) {
 			sendHelp(sender);
 			return true;
 		}
@@ -53,9 +52,9 @@ public class SquadsCMD implements CommandExecutor {
 
 		switch (args[0].toLowerCase()) {
 			case "list":
-				if (squad == null)
+				if (squad == null) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else {
+				} else {
 					player.sendMessage(Utils.translate("&9Squad Members:"));
 					squadsManager.getSquadMembers(squad).keySet().forEach(member -> player.sendMessage(Utils.translate("&9Sq -" + member.getDisplayName())));
 				}
@@ -65,24 +64,22 @@ public class SquadsCMD implements CommandExecutor {
 				if (n != 2) {
 					sendHelp(sender);
 					break;
-				}
-				else if (!player.inSquad()) {
+				} else if (!player.inSquad()) {
 					squadsManager.createSquad(player);
 					squad = player.getSquad();
-				}
-				else if (!SquadsManager.isLeader(player)) {
+				} else if (!SquadsManager.isLeader(player)) {
 					player.sendMessage(Utils.translate("&cYou are not the squad leader!"));
 					break;
 				}
 
 				PlayerStats invitee = Momentum.getStatsManager().getByName(args[1]);
-				if (invitee == null)
+				if (invitee == null) {
 					player.sendMessage(Utils.translate("&cThat player is not online!"));
-				else if (SquadsManager.isMember(squad, invitee))
+				} else if (SquadsManager.isMember(squad, invitee)) {
 					player.sendMessage(Utils.translate("&cThat player is already in the squad!"));
-				else if (squad.hasInvite(invitee))
+				} else if (squad.hasInvite(invitee)) {
 					player.sendMessage(Utils.translate("&cThat player has already been invited!"));
-				else {
+				} else {
 					squadsManager.invite(player, invitee);
 					SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName() + " &bhas invited &3" + invitee.getDisplayName() + " &bto the squad");
 
@@ -102,11 +99,11 @@ public class SquadsCMD implements CommandExecutor {
 					break;
 				}
 				PlayerStats inviter = Momentum.getStatsManager().getByName(args[1]);
-				if (inviter == null)
+				if (inviter == null) {
 					player.sendMessage(Utils.translate("&cThat player is not online!"));
-				else if (!inviter.inSquad() || !inviter.getSquad().hasInvite(player))
+				} else if (!inviter.inSquad() || !inviter.getSquad().hasInvite(player)) {
 					player.sendMessage(Utils.translate("&cNo incoming invites from &4" + inviter.getName() + " &cwere found"));
-				else {
+				} else {
 					Squad newSquad = inviter.getSquad();
 					boolean sqChat = squadsManager.isInSquadChat(player);
 					if (player.inSquad()) {
@@ -120,15 +117,16 @@ public class SquadsCMD implements CommandExecutor {
 					player.sendMessage(Utils.translate("&3You have joined the squad"));
 
 					// preserve squad chat if player leaves and rejoins/joins a new squad
-					if (sqChat)
+					if (sqChat) {
 						squadsManager.toggleSquadChat(player);
+					}
 				}
 
 				break;
 			case "leave":
-				if (!player.inSquad())
+				if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else {
+				} else {
 					boolean leader = SquadsManager.isLeader(player);
 					squadsManager.leave(player);
 					SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName() + " &bhas left the squad");
@@ -145,19 +143,19 @@ public class SquadsCMD implements CommandExecutor {
 
 				break;
 			case "kick":
-				if (n != 2)
+				if (n != 2) {
 					sendHelp(sender);
-				else if (!player.inSquad())
+				} else if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else if (!SquadsManager.isLeader(player))
+				} else if (!SquadsManager.isLeader(player)) {
 					player.sendMessage(Utils.translate("&cYou are not the squad leader!"));
-				else {
+				} else {
 					PlayerStats targetMember = Momentum.getStatsManager().getByName(args[1]);
-					if (targetMember == null || !SquadsManager.isMember(squad, targetMember))
+					if (targetMember == null || !SquadsManager.isMember(squad, targetMember)) {
 						player.sendMessage(Utils.translate("&cThat player is not in the squad!"));
-					else if (targetMember.equals(player))
+					} else if (targetMember.equals(player)) {
 						player.sendMessage(Utils.translate("&cYou cannot kick yourself!"));
-					else {
+					} else {
 						squadsManager.kick(targetMember);
 						SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName()  + " &bhas kicked &3" + targetMember.getDisplayName() + " &bfrom the squad");
 						targetMember.sendMessage(Utils.translate("&3You have been kicked from the squad"));
@@ -171,30 +169,30 @@ public class SquadsCMD implements CommandExecutor {
 
 				break;
 			case "disband":
-				if (!player.inSquad())
+				if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else if (!SquadsManager.isLeader(player))
+				} else if (!SquadsManager.isLeader(player)) {
 					player.sendMessage(Utils.translate("&cYou are not the squad leader!"));
-				else {
+				} else {
 					SquadsManager.notifyMembers(squad, "&3The squad has been disbanded");
 					squadsManager.disband(squad);
 				}
 
 				break;
 			case "promote":
-				if (n != 2)
+				if (n != 2) {
 					sendHelp(sender);
-				else if (!player.inSquad())
+				} else if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else if (!SquadsManager.isLeader(player))
+				} else if (!SquadsManager.isLeader(player)) {
 					player.sendMessage(Utils.translate("&cYou are not the squad leader!"));
-				else {
+				} else {
 					PlayerStats targetMember = Momentum.getStatsManager().getByName(args[1]);
-					if (targetMember == null || !SquadsManager.isMember(squad, targetMember))
+					if (targetMember == null || !SquadsManager.isMember(squad, targetMember)) {
 						player.sendMessage(Utils.translate("&cThat player is not in the squad!"));
-					else if (targetMember.equals(player))
+					} else if (targetMember.equals(player)) {
 						player.sendMessage(Utils.translate("&cYou cannot promote yourself!"));
-					else {
+					} else {
 						squadsManager.promote(targetMember);
 						SquadsManager.notifyMembers(squad, "&9SC &3" + targetMember.getDisplayName() + " &bhas been promoted to squad leader");
 					}
@@ -202,41 +200,44 @@ public class SquadsCMD implements CommandExecutor {
 
 				break;
 			case "chat":
-				if (!player.inSquad())
+				if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else if (n == 1)
+				} else if (n == 1) {
 					player.sendMessage(Utils.translate("&3You have toggled &9&lSquad Chat &b" + (squadsManager.toggleSquadChat(player) ? "on" : "off")));
-				else {
+				} else {
 					String msg = String.format("&9SC &3%s &b%s", player.getDisplayName(), String.join(" ", Arrays.copyOfRange(args, 1, n)));
 					squadsManager.sendMessage(player, msg, true);
 				}
 
 				break;
 			case "chatspy":
-				if (!sender.hasPermission("momentum.admin"))
+				if (!sender.hasPermission("momentum.admin")) {
 					sendHelp(sender);
-				else
+				} else {
 					player.sendMessage(Utils.translate("&3You have toggled &9&lSquad ChatSpy &b" + (squadsManager.toggleSquadChatSpy(player) ? "on" : "off")));
+				}
 
 				break;
 			case "warp":
 				Level level = player.getLevel();
 
-				if (!player.inSquad())
+				if (!player.inSquad()) {
 					sender.sendMessage(NO_SQUAD_MSG);
-				else if (!SquadsManager.isLeader(player))
+				} else if (!SquadsManager.isLeader(player)) {
 					player.sendMessage(Utils.translate("&cYou are not the squad leader!"));
-				else if (squad.hasWarpCooldown())
+				} else if (squad.hasWarpCooldown()) {
 					player.sendMessage(Utils.translate("&cWarp is on cooldown"));
-				else if (player.getPlayer().getWorld().getName().equalsIgnoreCase(Momentum.getSettingsManager().player_submitted_world))
+				} else if (player.getPlayer().getWorld().getName().equalsIgnoreCase(Momentum.getSettingsManager().player_submitted_world)) {
 					player.sendMessage(Utils.translate("&cYou cannot warp to a plot!"));
-				else if (!player.inLevel())
+				} else if (!player.inLevel()) {
 					player.sendMessage(Utils.translate("&cYou are not in a level!"));
-				else if (level.isAscendance())
+				} else if (level.isAscendance()) {
 					player.sendMessage(Utils.translate("&cYou cannot warp to ascendance!"));
-				else if (level.isEventLevel() || level.isRaceLevel())
+				} else if (level.isEventLevel()) {
 					player.sendMessage(Utils.translate("&cYou cannot warp to a race or event!"));
-				else {
+				} else if (player.inRace()) {
+					player.sendMessage(Utils.translate("&cYou cannot warp while in a race!"));
+				} else {
 					// notify first so failure messages send to individual players after
 					SquadsManager.notifyMembers(squad, "&9SC &3" + player.getDisplayName() + " &bhas warped to " + level.getFormattedTitle());
 					squadsManager.warpMembers(player);
@@ -267,7 +268,8 @@ public class SquadsCMD implements CommandExecutor {
 		sender.sendMessage(Utils.translate("&3/squads chat <message>  &bsends message to squad chat"));
 		sender.sendMessage(Utils.translate("&3/sqc <message>  &bsends message to squad chat"));
 		sender.sendMessage(Utils.translate("&3/squads warp  &bsends all players in squad to leader's level"));
-		if (sender.hasPermission("momentum.admin"))
+		if (sender.hasPermission("momentum.admin")) {
 			sender.sendMessage(Utils.translate("&3/squads chatspy  &btoggles squad chat spy"));
+		}
 	}
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/SettingsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/SettingsManager.java
@@ -154,6 +154,7 @@ public class SettingsManager {
     public int infinite_sprint_lb_size;
     public int levels_lb_size;
     public int prac_history_size;
+    public int max_mastery_lb_size;
 
     public SettingsManager(FileConfiguration settings) {
         cooldown_calendar = Calendar.getInstance();
@@ -411,5 +412,6 @@ public class SettingsManager {
         infinite_timed_lb_size = settings.getInt("leaderboard_max_size.infinite.timed");
         levels_lb_size = settings.getInt("leaderboard_max_size.levels");
         prac_history_size = settings.getInt("practice_history_size");
+        max_mastery_lb_size = settings.getInt("leaderboard_max_size.mastery");
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/checkpoints/CheckpointDB.java
@@ -47,6 +47,13 @@ public class CheckpointDB {
         );
     }
 
+    public static void deleteAllCheckpointsFromPlayer(String playerUUID) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.LEVEL_CHECKPOINTS_TABLE + " WHERE uuid=?",
+                playerUUID
+        );
+    }
+
     public static void updateCheckpoint(PlayerStats playerStats, Location newLocation) {
         DatabaseQueries.runAsyncQuery(
                 "UPDATE " + DatabaseManager.LEVEL_CHECKPOINTS_TABLE + " SET world=?, x=?, y=?, z=? WHERE level_name=? AND uuid=?",

--- a/src/main/java/com/renatusnetwork/momentum/data/clans/ClansManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/clans/ClansManager.java
@@ -95,7 +95,7 @@ public class ClansManager {
 
     public void kickMember(Clan clan, String playerName) {
         clan.removeMember(playerName);
-        StatsDB.resetPlayerClan(playerName);
+        StatsDB.resetPlayerClanByName(playerName);
 
         PlayerStats victimStats = Momentum.getStatsManager().getByName(playerName);
 
@@ -276,7 +276,7 @@ public class ClansManager {
 
     public void leaveClan(Clan clan, PlayerStats playerStats) {
         // reset cache
-        StatsDB.resetPlayerClan(playerStats.getName());
+        StatsDB.resetPlayerClanByName(playerStats.getName());
         clan.removeMember(playerStats.getName());
 
         playerStats.resetClan();

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -86,6 +86,13 @@ public class CmdSignsDB {
         );
     }
 
+    public static void unuseAllCommandSigns(String uuid) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.USED_COMMAND_SIGNS + " WHERE uuid=?",
+                uuid
+        );
+    }
+
     public static void updateCommand(String name, String oldCommand, String newCommand) {
         DatabaseQueries.runAsyncQuery(
                 "UPDATE " + DatabaseManager.COMMAND_SIGNS_COMMANDS + " SET command=? WHERE name=? AND command=?",

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CmdSignsDB.java
@@ -58,10 +58,10 @@ public class CmdSignsDB {
         ).stream().map(res -> res.get("command")).collect(Collectors.toList());
     }
 
-    public static void insertCommandSign(String name, String command, String world, int x, int y, int z) {
+    public static void insertCommandSign(String name, String world, int x, int y, int z) {
         DatabaseQueries.runAsyncQuery(
-                "INSERT INTO " + DatabaseManager.COMMAND_SIGNS + " (name, command, world, x, y, z) VALUES (?,?,?,?,?,?)",
-                name, command, world, x, y, z
+                "INSERT INTO " + DatabaseManager.COMMAND_SIGNS + " (name, world, x, y, z) VALUES (?,?,?,?,?)",
+                name, world, x, y, z
         );
     }
 

--- a/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/cmdsigns/CommandSignManager.java
@@ -5,7 +5,6 @@ import com.renatusnetwork.momentum.data.stats.PlayerStats;
 import org.bukkit.World;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class CommandSignManager {
 
@@ -28,13 +27,13 @@ public class CommandSignManager {
         CmdSignsDB.insertUsedCommandSign(playerStats.getUUID(), name);
     }
 
-    public void addCommandSign(String name, String command, World world, int x, int y, int z) {
+    public void addCommandSign(String name, World world, int x, int y, int z) {
         CmdSignLocation loc = new CmdSignLocation(world, x, y, z);
-        CommandSign csign = new CommandSign(name, null, command == null ? new ArrayList<>() : new ArrayList<>(Collections.singletonList(command)), loc, false);
+        CommandSign csign = new CommandSign(name, null, new ArrayList<>(), loc, false);
 
         cmdSigns.put(name, csign);
         locations.put(loc, csign);
-        CmdSignsDB.insertCommandSign(name, command, world.getName(), x, y, z);
+        CmdSignsDB.insertCommandSign(name, world.getName(), x, y, z);
     }
 
     public void deleteCommandSign(String name) {

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTierDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTierDB.java
@@ -43,4 +43,7 @@ public class ELOTierDB {
         DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.ELO_TIERS + " SET previous_elo_tier=? WHERE name=?", previousTier, name);
     }
 
+    public static void deleteTier(String name) {
+        DatabaseQueries.runAsyncQuery("DELETE FROM " + DatabaseManager.ELO_TIERS + " WHERE name=?", name);
+    }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/elo/ELOTiersManager.java
@@ -41,6 +41,23 @@ public class ELOTiersManager {
         ELOTierDB.updatePreviousTier(tier.getName(), previousELOTier);
     }
 
+    public void deleteELOTier(ELOTier tier) {
+        ELOTier next = tier.getNextELOTier();
+        ELOTier prev = tier.getPreviousELOTier();
+
+        if (next != null && prev != null) {
+            prev.setNextELOTier(next.getName());
+            next.setPreviousELOTier(prev.getName());
+        } else if (next != null) {
+            next.setPreviousELOTier(null);
+        } else if (prev != null) {
+            prev.setNextELOTier(null);
+        }
+
+        tiers.remove(tier.getName());
+        ELOTierDB.deleteTier(tier.getName());
+    }
+
     public ELOTier calculateELOTierDirectly(int elo) {
         ELOTier tier = tiers.get(Momentum.getSettingsManager().default_elo_tier);
         ELOTier next = tier.getNextELOTier();

--- a/src/main/java/com/renatusnetwork/momentum/data/leaderboards/MasteryLBPosition.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/leaderboards/MasteryLBPosition.java
@@ -1,0 +1,19 @@
+package com.renatusnetwork.momentum.data.leaderboards;
+
+public class MasteryLBPosition {
+    private String playerName;
+    private int masteryCompletions;
+
+    public MasteryLBPosition(String playerName, int masteryCompletions) {
+        this.playerName = playerName;
+        this.masteryCompletions = masteryCompletions;
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public int getMasteryCompletions() {
+        return masteryCompletions;
+    }
+}

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/CompletionsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/CompletionsDB.java
@@ -262,6 +262,16 @@ public class CompletionsDB {
         return leaderboard;
     }
 
+    public static int getPlayerLevelCompletionsCount(String uuid, String levelName) {
+        Map<String, String> count = DatabaseQueries.getResult(
+                DatabaseManager.LEVEL_COMPLETIONS_TABLE, "COUNT(*) AS completions_count",
+                "WHERE uuid=? AND level_name=?",
+                uuid, levelName
+        );
+
+        return Integer.parseInt(count.get("completions_count"));
+    }
+
     public static boolean isFasterThanRecord(LevelCompletion levelCompletion) {
         Map<String, String> singleResult = DatabaseQueries.getResult(
                 DatabaseManager.LEVEL_COMPLETIONS_TABLE, "MIN(time_taken) AS fastest",

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/CompletionsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/CompletionsDB.java
@@ -113,6 +113,16 @@ public class CompletionsDB {
         }
     }
 
+    public static void removeAllCompletionsFromPlayer(String playerUUID, boolean timedOnly, boolean async) {
+        String query = "DELETE FROM " + DatabaseManager.LEVEL_COMPLETIONS_TABLE + " WHERE uuid=?" + (timedOnly ? " AND time_taken IS NOT NULL" : "");
+
+        if (async) {
+            DatabaseQueries.runAsyncQuery(query, playerUUID);
+        } else {
+            DatabaseQueries.runQuery(query, playerUUID);
+        }
+    }
+
     public static boolean hasCompleted(String uuid, String levelName) {
         Map<String, String> playerResult = DatabaseQueries.getResult(DatabaseManager.LEVEL_COMPLETIONS_TABLE, "*",
                                                                      " WHERE uuid=? AND level_name=?", uuid, levelName);

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/Level.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/Level.java
@@ -37,7 +37,6 @@ public class Level {
     private boolean cooldown;
     private LevelType type;
     private boolean newLevel;
-    private boolean legacyLevel;
     private boolean hasMastery;
     private float masteryMultiplier;
     private boolean tc;
@@ -426,24 +425,12 @@ public class Level {
         return newLevel;
     }
 
-    public boolean isLegacy() {
-        return legacyLevel;
-    }
-
     public void toggleNew() {
         newLevel = !newLevel;
     }
 
-    public void toggleLegacy() {
-        legacyLevel = !legacyLevel;
-    }
-
     public void setNew(boolean isNew) {
         this.newLevel = isNew;
-    }
-
-    public void setLegacy(boolean isLegacy) {
-        this.legacyLevel = isLegacy;
     }
 
     public boolean hasMastery() {
@@ -539,6 +526,5 @@ public class Level {
     public boolean equals(String levelName) {
         return this.name.equalsIgnoreCase(levelName);
     }
-
 
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/Level.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/Level.java
@@ -37,6 +37,7 @@ public class Level {
     private boolean cooldown;
     private LevelType type;
     private boolean newLevel;
+    private boolean legacyLevel;
     private boolean hasMastery;
     private float masteryMultiplier;
     private boolean tc;
@@ -425,12 +426,24 @@ public class Level {
         return newLevel;
     }
 
+    public boolean isLegacy() {
+        return legacyLevel;
+    }
+
     public void toggleNew() {
         newLevel = !newLevel;
     }
 
+    public void toggleLegacy() {
+        legacyLevel = !legacyLevel;
+    }
+
     public void setNew(boolean isNew) {
         this.newLevel = isNew;
+    }
+
+    public void setLegacy(boolean isLegacy) {
+        this.legacyLevel = isLegacy;
     }
 
     public boolean hasMastery() {
@@ -526,5 +539,6 @@ public class Level {
     public boolean equals(String levelName) {
         return this.name.equalsIgnoreCase(levelName);
     }
+
 
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -371,6 +371,10 @@ public class LevelManager {
                 HashMap<String, PlayerStats> stats = Momentum.getStatsManager().getPlayerStats();
 
                 synchronized (stats) {
+                    for (Level level : levels.values()) {
+                        level.setPlayersInLevel(0);
+                    }
+
                     for (PlayerStats playerStats : stats.values()) {
                         Level level = playerStats.getLevel();
 
@@ -383,8 +387,6 @@ public class LevelManager {
                             }
                         }
                     }
-
-                    levels.values().stream().filter(l -> !amountInLevel.containsKey(l)).forEach(l -> l.setPlayersInLevel(0));
 
                     // set in level amount
                     for (Map.Entry<Level, Integer> entry : amountInLevel.entrySet()) {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -151,7 +151,14 @@ public class LevelManager {
 
     public void toggleNew(Level level) {
         level.toggleNew();
+        level.setLegacy(false);
         LevelsDB.updateNew(level.getName());
+    }
+
+    public void toggleLegacy(Level level) {
+        level.toggleLegacy();
+        level.setNew(false);
+        LevelsDB.updateLegacy(level.getName());
     }
 
     public void toggleTC(Level level) {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -983,63 +983,22 @@ public class LevelManager {
             // Update player information
             playerStats.levelCompletion(levelCompletion);
 
-            // add mastery
-            if (completedMastery) {
-                playerStats.addMasteryCompletion(level.getName());
-                Momentum.getStatsManager().leftMastery(playerStats);
-            }
             JackpotManager jackpotManager = Momentum.getJackpotManager();
 
-            // give higher reward if prestiged
-            int reward = event.getReward();
+            int reward = calculateLevelRewardForPlayer(playerStats, level);
 
-            // level booster
-            if (playerStats.hasModifier(ModifierType.LEVEL_BOOSTER)) {
-                Booster booster = (Booster) playerStats.getModifier(ModifierType.LEVEL_BOOSTER);
-                reward *= booster.getMultiplier();
-            }
-
-            // if mastery, boost it
-            if (completedMastery) {
-                reward *= level.getMasteryMultiplier();
-            }
-            // if featured, set reward!
-            else if (level.isFeaturedLevel()) {
-                reward *= Momentum.getSettingsManager().featured_level_reward_multiplier;
-            }
-            // jackpot section
-            else if (jackpotManager.isJackpotRunning() &&
+            if (jackpotManager.isJackpotRunning() &&
                     jackpotManager.getJackpot().getLevelName().equalsIgnoreCase(level.getName()) &&
-                     !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {
+                    !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {
                 Jackpot jackpot = jackpotManager.getJackpot();
 
                 JackpotRewardEvent jackpotEvent = new JackpotRewardEvent(playerStats, jackpot.getLevel(), jackpot.getBonus());
                 Bukkit.getPluginManager().callEvent(jackpotEvent);
 
                 if (!jackpotEvent.isCancelled()) {
-                    int bonus = jackpotEvent.getBonus();
-
-                    // jackpot booster
-                    if (playerStats.hasModifier(ModifierType.JACKPOT_BOOSTER)) {
-                        Booster booster = (Booster) playerStats.getModifier(ModifierType.JACKPOT_BOOSTER);
-                        bonus *= booster.getMultiplier();
-                    }
-
                     // add coins and add to completed, as well as broadcast completion
                     jackpot.addCompleted(player.getName());
                     jackpot.broadcastCompletion(player);
-                    reward += bonus;
-                }
-            }
-            // prestige/cooldown section
-            else {
-                if (playerStats.hasPrestiges() && level.hasReward()) {
-                    reward *= playerStats.getPrestigeMultiplier();
-                }
-
-                // set cooldown modifier last!
-                if (level.hasCooldown() && inCooldownMap(playerStats.getName())) {
-                    reward *= getLevelCooldown(playerStats.getName()).getModifier();
                 }
             }
 
@@ -1228,6 +1187,50 @@ public class LevelManager {
 
             CompletionsDB.insertCompletion(levelCompletion, completedMastery);
         }
+    }
+
+    // calculates level reward player WOULD get for the given level
+    public int calculateLevelRewardForPlayer(PlayerStats playerStats, Level level) {
+        int baseReward = level.getReward();
+        JackpotManager jackpotManager = Momentum.getJackpotManager();
+
+        // level booster
+        if (playerStats.hasModifier(ModifierType.LEVEL_BOOSTER)) {
+            Booster booster = (Booster) playerStats.getModifier(ModifierType.LEVEL_BOOSTER);
+            baseReward *= booster.getMultiplier();
+        }
+
+        // if mastery, boost it
+        if (level.hasMastery() && playerStats.isAttemptingMastery()) {
+            baseReward *= level.getMasteryMultiplier();
+        } else if (level.isFeaturedLevel()) { // if featured, set reward!
+            baseReward *= Momentum.getSettingsManager().featured_level_reward_multiplier;
+        } else if (jackpotManager.isJackpotRunning() &&
+                jackpotManager.getJackpot().getLevelName().equalsIgnoreCase(level.getName()) &&
+                !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) { // jackpot section
+            Jackpot jackpot = jackpotManager.getJackpot();
+
+            int bonus = jackpot.getBonus();
+
+            // jackpot booster
+            if (playerStats.hasModifier(ModifierType.JACKPOT_BOOSTER)) {
+                Booster booster = (Booster) playerStats.getModifier(ModifierType.JACKPOT_BOOSTER);
+                bonus *= booster.getMultiplier();
+            }
+
+            baseReward += bonus;
+        } else { // prestige/cooldown section
+            if (playerStats.hasPrestiges() && level.hasReward()) {
+                baseReward *= playerStats.getPrestigeMultiplier();
+            }
+
+            // set cooldown modifier last!
+            if (level.hasCooldown() && inCooldownMap(playerStats.getName())) {
+                baseReward *= getLevelCooldown(playerStats.getName()).getModifier();
+            }
+        }
+
+        return baseReward;
     }
 
     // Respawn player if checkpoint isn't there

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -710,6 +710,10 @@ public class LevelManager {
         totalLevelCompletions--;
     }
 
+    public void removeTotalLevelCompletion(int count) {
+        totalLevelCompletions -= count;
+    }
+
 
     // top rated levels lb
     public void loadTopRatedLevelsLB() {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -384,6 +384,8 @@ public class LevelManager {
                         }
                     }
 
+                    levels.values().stream().filter(l -> !amountInLevel.containsKey(l)).forEach(l -> l.setPlayersInLevel(0));
+
                     // set in level amount
                     for (Map.Entry<Level, Integer> entry : amountInLevel.entrySet()) {
                         entry.getKey().setPlayersInLevel(entry.getValue());

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -151,14 +151,7 @@ public class LevelManager {
 
     public void toggleNew(Level level) {
         level.toggleNew();
-        level.setLegacy(false);
         LevelsDB.updateNew(level.getName());
-    }
-
-    public void toggleLegacy(Level level) {
-        level.toggleLegacy();
-        level.setNew(false);
-        LevelsDB.updateLegacy(level.getName());
     }
 
     public void toggleTC(Level level) {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelManager.java
@@ -806,7 +806,7 @@ public class LevelManager {
                 RanksManager ranksManager = Momentum.getRanksManager();
                 if (!(level.needsRank() && ranksManager.isPastOrAtRank(playerStats, level.getRequiredRank()))) {
                     if (!level.isEventLevel()) {
-                        if (!level.isRaceLevel()) {
+                        //if (!level.isRaceLevel()) {
                             if (!playerStats.getPlayer().getWorld().getName().equalsIgnoreCase(Momentum.getSettingsManager().player_submitted_world)) {
                                 boolean teleport = true;
 
@@ -826,9 +826,9 @@ public class LevelManager {
                             } else {
                                 player.sendMessage(Utils.translate("&cYou cannot teleport to a level from the plot world, do /spawn first"));
                             }
-                        } else {
-                            player.sendMessage(Utils.translate("&cYou cannot teleport to a Race level"));
-                        }
+                        //} else {
+                        //    player.sendMessage(Utils.translate("&cYou cannot teleport to a Race level"));
+                        //}
                     } else {
                         player.sendMessage(Utils.translate("&cYou cannot teleport to an Event level"));
                     }

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelPreview.java
@@ -33,5 +33,6 @@ public class LevelPreview {
 
     public void reset() {
         playerStats.teleport(oldLocation, true);
+        Utils.removeLeaveItem(playerStats.getPlayer());
     }
 }

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
@@ -90,6 +90,7 @@ public class LevelsDB {
             level.setBroadcast(Integer.parseInt(result.get("broadcast")) == 1);
             level.setLiquidResetPlayer(Integer.parseInt(result.get("liquid_reset")) == 0); // default is 0!
             level.setNew(Integer.parseInt(result.get("new")) == 1);
+            level.setLegacy(Integer.parseInt(result.get("legacy")) == 1);
             level.setHasMastery(Integer.parseInt(result.get("has_mastery")) == 1);
             level.setTC(Integer.parseInt(result.get("tc")) == 1);
 
@@ -254,6 +255,12 @@ public class LevelsDB {
 
     public static void updateNew(String levelName) {
         DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET new=NOT new WHERE name=?", levelName);
+        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET legacy=0 WHERE name=?", levelName);
+    }
+
+    public static void updateLegacy(String levelName) {
+        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET legacy=NOT legacy WHERE name=?", levelName);
+        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET new=1 WHERE name=?", levelName);
     }
 
     public static void updateHasMastery(String levelName) {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
@@ -90,7 +90,6 @@ public class LevelsDB {
             level.setBroadcast(Integer.parseInt(result.get("broadcast")) == 1);
             level.setLiquidResetPlayer(Integer.parseInt(result.get("liquid_reset")) == 0); // default is 0!
             level.setNew(Integer.parseInt(result.get("new")) == 1);
-            level.setLegacy(Integer.parseInt(result.get("legacy")) == 1);
             level.setHasMastery(Integer.parseInt(result.get("has_mastery")) == 1);
             level.setTC(Integer.parseInt(result.get("tc")) == 1);
 
@@ -262,12 +261,6 @@ public class LevelsDB {
 
     public static void updateNew(String levelName) {
         DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET new=NOT new WHERE name=?", levelName);
-        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET legacy=0 WHERE name=?", levelName);
-    }
-
-    public static void updateLegacy(String levelName) {
-        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET legacy=NOT legacy WHERE name=?", levelName);
-        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.LEVELS_TABLE + " SET new=1 WHERE name=?", levelName);
     }
 
     public static void updateHasMastery(String levelName) {

--- a/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/levels/LevelsDB.java
@@ -193,6 +193,13 @@ public class LevelsDB {
         return ratings;
     }
 
+    public static void removeAllLevelRatingsFromPlayer(String playerUUID) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.LEVEL_RATINGS_TABLE + " WHERE uuid=?",
+                playerUUID
+        );
+    }
+
     public static void insertLevel(String levelName, long creationMillis) {
         DatabaseQueries.runAsyncQuery("INSERT INTO " + DatabaseManager.LEVELS_TABLE + "(name, creation_date) VALUES (?,?)",
                                       levelName, creationMillis);

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemAction.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemAction.java
@@ -3,6 +3,7 @@ package com.renatusnetwork.momentum.data.menus;
 import com.renatusnetwork.momentum.Momentum;
 import com.renatusnetwork.momentum.api.LevelBuyEvent;
 import com.renatusnetwork.momentum.api.ShopBuyEvent;
+import com.renatusnetwork.momentum.data.SettingsManager;
 import com.renatusnetwork.momentum.data.infinite.gamemode.InfiniteType;
 import com.renatusnetwork.momentum.data.jackpot.JackpotManager;
 import com.renatusnetwork.momentum.data.levels.Level;
@@ -385,7 +386,12 @@ public class MenuItemAction {
                 !(jackpotManager.isJackpotRunning() && jackpotManager.getJackpot().getLevelName().equalsIgnoreCase(level.getName())) &&
                 !playerStats.hasBoughtLevel(level) && !playerStats.hasCompleted(level)) {
                 if (Momentum.getMenuManager().containsShiftClicked(playerStats)) {
-                    performLevelPreview(playerStats, level);
+                    if (playerStats.isPreviewingLevel()) {
+                        playerStats.sendMessage(Utils.translate("&cYou are already previewing a level. Type &4/preview leave &cor use the &4Leave &citem before attempting to preview another level."));
+                        playerStats.getPlayer().closeInventory();
+                    } else {
+                        performLevelPreview(playerStats, level);
+                    }
                 } else {
                     performLevelBuying(playerStats, level, menuItem);
                 }
@@ -398,6 +404,7 @@ public class MenuItemAction {
     public static void performLevelPreview(PlayerStats playerStats, Level level) {
         Player player = playerStats.getPlayer();
         player.closeInventory();
+        SettingsManager settingsManager = Momentum.getSettingsManager();
 
         if (nonLevelTeleportConditions(playerStats)) {
             if (playerStats.inPracticeMode()) {
@@ -408,6 +415,10 @@ public class MenuItemAction {
             LevelPreview levelPreview = new LevelPreview(playerStats, level, player.getLocation());
             playerStats.setPreviewLevel(levelPreview);
             levelPreview.teleport();
+
+            if (Utils.getItemStackIfExists(player, player.getInventory(), settingsManager.leave_title) == null) {
+                Utils.addItemToHotbar(settingsManager.leave_item, player.getInventory(), settingsManager.leave_hotbar_slot);
+            }
 
             player.sendMessage(Utils.translate(
                     "&7You are now previewing &c" + level.getTitle() + "&7, you can only move in a &6" + ((int) Momentum.getSettingsManager().preview_max_distance) + "&7 block radius"

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
@@ -447,6 +447,8 @@ public class MenuItemFormatter {
                 // add new if new level! but dont show new if featured (too messy)
                 if (level.isNew()) {
                     formattedTitle = Utils.translate("&d&lNEW " + formattedTitle);
+                } else if (level.isLegacy()) {
+                    formattedTitle = Utils.translate("&8&lLEGACY " + formattedTitle);
                 }
                 // show jackpot info if is running and not completed
                 else if (jackpotManager.isJackpotRunning() && jackpotManager.getJackpot().getLevel().equals(level) && !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
@@ -551,45 +551,8 @@ public class MenuItemFormatter {
             }
 
             int oldReward = level.getReward();
-            int newReward = oldReward;
+            int newReward = Momentum.getLevelManager().calculateLevelRewardForPlayer(playerStats, level);
             LevelCooldown cooldown = null;
-
-            if (playerStats.hasModifier(ModifierType.LEVEL_BOOSTER)) {
-                // downcast and boost
-                Booster booster = (Booster) playerStats.getModifier(ModifierType.LEVEL_BOOSTER);
-                newReward *= booster.getMultiplier();
-            }
-
-            if (level.isFeaturedLevel()) {
-                newReward *= Momentum.getSettingsManager().featured_level_reward_multiplier;
-            }
-            // jackpot section
-            else if (jackpotManager.isJackpotRunning() &&
-                    jackpotManager.getJackpot().getLevelName().equalsIgnoreCase(level.getName()) &&
-                     !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {
-                Jackpot jackpot = jackpotManager.getJackpot();
-
-                int bonus = jackpot.getBonus();
-
-                if (playerStats.hasModifier(ModifierType.JACKPOT_BOOSTER)) {
-                    // downcast and boost
-                    Booster booster = (Booster) playerStats.getModifier(ModifierType.JACKPOT_BOOSTER);
-                    bonus *= booster.getMultiplier();
-                }
-                newReward += bonus;
-            }
-            // only do these if jackpot is not running!
-            else {
-                if (playerStats.hasPrestiges() && level.hasReward()) {
-                    newReward *= playerStats.getPrestigeMultiplier();
-                }
-
-                // set cooldown modifier last!
-                if (level.hasCooldown() && Momentum.getLevelManager().inCooldownMap(playerStats.getName())) {
-                    cooldown = Momentum.getLevelManager().getLevelCooldown(playerStats.getName());
-                    newReward *= cooldown.getModifier();
-                }
-            }
 
             // set modified, extra check for times of when max prestige = +25% and cooldown = -25%
             if (oldReward != newReward) {

--- a/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/menus/MenuItemFormatter.java
@@ -447,8 +447,6 @@ public class MenuItemFormatter {
                 // add new if new level! but dont show new if featured (too messy)
                 if (level.isNew()) {
                     formattedTitle = Utils.translate("&d&lNEW " + formattedTitle);
-                } else if (level.isLegacy()) {
-                    formattedTitle = Utils.translate("&8&lLEGACY " + formattedTitle);
                 }
                 // show jackpot info if is running and not completed
                 else if (jackpotManager.isJackpotRunning() && jackpotManager.getJackpot().getLevel().equals(level) && !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {

--- a/src/main/java/com/renatusnetwork/momentum/data/perks/PerkManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/perks/PerkManager.java
@@ -5,6 +5,7 @@ import com.renatusnetwork.momentum.data.elo.ELOTier;
 import com.renatusnetwork.momentum.data.levels.Level;
 import com.renatusnetwork.momentum.data.stats.PlayerStats;
 import com.renatusnetwork.momentum.data.stats.StatsDB;
+import com.renatusnetwork.momentum.utils.Utils;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -102,28 +103,31 @@ public class PerkManager {
         ItemStack item = perk.getArmorPiece(type);
         ItemMeta itemMeta = item.getItemMeta();
 
-        itemMeta.setDisplayName(title);
+        itemMeta.setDisplayName(Utils.translate(title));
         item.setItemMeta(itemMeta);
 
         PerksDB.updateArmorTitle(perk.getName(), type.name(), title);
     }
 
-    public boolean updateArmorGlow(Perk perk, PerksArmorType type) {
+    public boolean toggleArmorGlow(Perk perk, PerksArmorType type) {
         ItemStack item = perk.getArmorPiece(type);
         ItemMeta itemMeta = item.getItemMeta();
 
-        boolean glow = itemMeta.hasEnchant(Enchantment.DURABILITY);
+        boolean isGlowing = itemMeta.hasEnchant(Enchantment.DURABILITY);
 
-        if (!glow) {
+        if (isGlowing) {
             itemMeta.removeEnchant(Enchantment.DURABILITY);
             itemMeta.removeItemFlags(ItemFlag.HIDE_ENCHANTS);
+        } else {
+            itemMeta.addEnchant(Enchantment.DURABILITY, 1, true);
+            itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
 
         item.setItemMeta(itemMeta);
 
-        PerksDB.updateArmorGlow(perk.getName(), type.name());
+        PerksDB.toggleArmorGlow(perk.getName(), type.name());
 
-        return glow; // return the value of the glow
+        return !isGlowing; // return the value of the glow
     }
 
     public void updateArmorMaterial(Perk perk, PerksArmorType type, Material material) {

--- a/src/main/java/com/renatusnetwork/momentum/data/perks/PerksDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/perks/PerksDB.java
@@ -75,7 +75,7 @@ public class PerksDB {
         );
     }
 
-    public static void updateArmorGlow(String perkName, String armorPiece) {
+    public static void toggleArmorGlow(String perkName, String armorPiece) {
         DatabaseQueries.runAsyncQuery(
                 "UPDATE " + DatabaseManager.PERKS_ARMOR_TABLE + " SET glow=NOT glow WHERE perk_name=? AND armor_piece=?", perkName, armorPiece
         );

--- a/src/main/java/com/renatusnetwork/momentum/data/placeholders/LBPlaceholders.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/placeholders/LBPlaceholders.java
@@ -176,6 +176,22 @@ public class LBPlaceholders {
                             }
                             break;
                         }
+                        case "mastery": {
+                            ArrayList<MasteryLBPosition> leaderboard = Momentum.getStatsManager().getMasteryLB();
+
+                            if (leaderboard.size() > posInt) {
+                                MasteryLBPosition masteryLbPosition = leaderboard.get(posInt);
+
+                                if (masteryLbPosition != null) {
+                                    if (value.equals("name")) {
+                                        return masteryLbPosition.getPlayerName();
+                                    } else if (value.equals("progress")) {
+                                        return Utils.formatNumber(masteryLbPosition.getMasteryCompletions()) + "/" + Utils.formatNumber(Momentum.getLevelManager().getNumMasteryLevels());
+                                    }
+                                }
+                            }
+                            break;
+                        }
                         default: {
                             Level level = Momentum.getLevelManager().get(type);
 

--- a/src/main/java/com/renatusnetwork/momentum/data/placeholders/PlayerPlaceholders.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/placeholders/PlayerPlaceholders.java
@@ -29,6 +29,8 @@ public class PlayerPlaceholders {
                     return Utils.formatNumber(playerStats.getTotalLevelCompletions());
                 case "mastery_completions":
                     return Utils.formatNumber(playerStats.getNumMasteryCompletions());
+                case "mastery_progress":
+                    return Utils.formatNumber(playerStats.getNumMasteryCompletions()) + "/" + Utils.formatNumber(Momentum.getLevelManager().getNumMasteryLevels());
                 case "race_wins":
                     return Utils.formatNumber(playerStats.getRaceWins());
                 case "race_losses":

--- a/src/main/java/com/renatusnetwork/momentum/data/saves/SavesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/saves/SavesDB.java
@@ -63,6 +63,13 @@ public class SavesDB {
                 playerName, levelName);
     }
 
+    public static void removeAllSavesFromPlayer(String playerUUID) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.LEVEL_SAVES_TABLE + " WHERE uuid=?",
+                playerUUID
+        );
+    }
+
     public static void updateSave(String uuid, String levelName, Location newLocation) {
         DatabaseQueries.runAsyncQuery(
                 "UPDATE " + DatabaseManager.LEVEL_SAVES_TABLE +

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/PlayerStats.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/PlayerStats.java
@@ -27,7 +27,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
@@ -407,7 +406,7 @@ public class PlayerStats {
 
     public void resetLevel() {
         level = null;
-        Utils.removeSpawnItemIfExists(player);
+        Utils.removeLeaveItem(player);
     }
 
     public Level getLevel() {

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/PlayerStats.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/PlayerStats.java
@@ -973,6 +973,10 @@ public class PlayerStats {
         }
     }
 
+    public void removeCompletions(String levelName) {
+        levelCompletions.remove(levelName);
+    }
+
     //
     // Perks Section
     //

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsDB.java
@@ -12,9 +12,7 @@ import com.renatusnetwork.momentum.data.modifiers.ModifierType;
 import com.renatusnetwork.momentum.data.ranks.Rank;
 import com.renatusnetwork.momentum.storage.mysql.DatabaseManager;
 import com.renatusnetwork.momentum.storage.mysql.DatabaseQueries;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -452,6 +450,13 @@ public class StatsDB {
                 uuid, boughtLevel);
     }
 
+    public static void removeAllFavoriteLevels(String uuid) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.FAVORITE_LEVELS + " WHERE uuid=?",
+                uuid
+        );
+    }
+
     public static void addBoughtLevel(String uuid, String boughtLevel) {
         DatabaseQueries.runAsyncQuery(
                 "INSERT INTO " + DatabaseManager.LEVEL_PURCHASES_TABLE + " (uuid, level_name)" +
@@ -464,6 +469,13 @@ public class StatsDB {
         DatabaseQueries.runAsyncQuery(
                 "DELETE FROM " + DatabaseManager.LEVEL_PURCHASES_TABLE + " WHERE uuid=? AND level_name=?",
                 uuid, boughtLevel);
+    }
+
+    public static void removeAllBoughtLevels(String uuid) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.LEVEL_PURCHASES_TABLE + " WHERE uuid=?",
+                uuid
+        );
     }
 
     public static void removeBoughtLevelByName(String playerName, String boughtLevel) {
@@ -484,8 +496,12 @@ public class StatsDB {
         return !playerResult.isEmpty();
     }
 
-    public static void resetPlayerClan(String playerName) {
+    public static void resetPlayerClanByName(String playerName) {
         DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.PLAYERS_TABLE + " SET clan=NULL WHERE name=?", playerName);
+    }
+
+    public static void resetPlayerClanByUUID(String playerUUID) {
+        DatabaseQueries.runAsyncQuery("UPDATE " + DatabaseManager.PLAYERS_TABLE + " SET clan=NULL WHERE uuid=?", playerUUID);
     }
 
     public static void updatePlayerClan(String uuid, String tag) {
@@ -525,6 +541,13 @@ public class StatsDB {
                 "DELETE FROM " + DatabaseManager.PLAYER_MODIFIERS_TABLE + " WHERE uuid=? AND modifier_name=?",
                 uuid, modifierName
                                      );
+    }
+
+    public static void removeAllModifiersFromPlayer(String playerUUID) {
+        DatabaseQueries.runAsyncQuery(
+                "DELETE FROM " + DatabaseManager.PLAYER_MODIFIERS_TABLE + " WHERE uuid=?",
+                playerUUID
+        );
     }
 
     public static void removeModifierName(String playerName, String modifierName) {

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -805,6 +805,10 @@ public class StatsManager {
                 spectator.setFlying(true);
             }
 
+            // unobtrusive invis
+            spectator.removePotionEffect(PotionEffectType.INVISIBILITY); // remove before adding to refresh timer
+            spectator.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 20 * 5, 1, false, false));
+
             spectatorStats.sendTitle("&7Teleported to " + player.getDisplayName(), "&2/spectate &7 to exit", 10, 40, 10);
         }
     }

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -9,6 +9,7 @@ import com.renatusnetwork.momentum.data.elo.ELOOutcomeTypes;
 import com.renatusnetwork.momentum.data.elo.ELOTier;
 import com.renatusnetwork.momentum.data.infinite.gamemode.InfiniteType;
 import com.renatusnetwork.momentum.data.leaderboards.ELOLBPosition;
+import com.renatusnetwork.momentum.data.leaderboards.MasteryLBPosition;
 import com.renatusnetwork.momentum.data.levels.CompletionsDB;
 import com.renatusnetwork.momentum.data.levels.Level;
 import com.renatusnetwork.momentum.data.menus.LevelSortingType;
@@ -53,6 +54,7 @@ public class StatsManager {
     private ArrayList<GlobalPersonalLBPosition> globalPersonalCompletionsLB;
     private ArrayList<CoinsLBPosition> coinsLB;
     private ArrayList<ELOLBPosition> eloLB;
+    private ArrayList<MasteryLBPosition> masteryLB;
     private HashMap<String, ELOLBPosition> eloLBNames;
 
     private HashSet<String> saidGG;
@@ -71,6 +73,7 @@ public class StatsManager {
         this.globalPersonalCompletionsLB = new ArrayList<>(Momentum.getSettingsManager().max_global_personal_completions_leaderboard_size);
         this.coinsLB = new ArrayList<>(Momentum.getSettingsManager().max_coins_leaderboard_size);
         this.eloLB = new ArrayList<>(Momentum.getSettingsManager().elo_lb_size);
+        this.masteryLB = new ArrayList<>(Momentum.getSettingsManager().max_mastery_lb_size);
         this.eloLBNames = new HashMap<>(Momentum.getSettingsManager().elo_lb_size);
         this.hiddenPlayers = new HashSet<>();
         this.saidGG = new HashSet<>();
@@ -89,6 +92,7 @@ public class StatsManager {
                 loadCoinsLB();
                 loadTotalCoins();
                 loadELOLB();
+                loadMasteryLB();
             }
         }.runTaskTimerAsynchronously(plugin, 20 * 30, 20 * 180);
 
@@ -626,12 +630,43 @@ public class StatsManager {
         }
     }
 
+    public void loadMasteryLB() {
+        try {
+            masteryLB.clear();
+
+            List<Map<String, String>> masteryCompletions = DatabaseQueries.getResults(
+                        DatabaseManager.LEVEL_COMPLETIONS_TABLE + " lc",
+                    "p.name, COUNT(*) AS total_mastery_completions",
+                    "JOIN " + DatabaseManager.PLAYERS_TABLE + " p ON p.uuid=lc.uuid " +
+                            "WHERE lc.mastery=1 " +
+                            "GROUP BY p.name " +
+                            "ORDER BY total_mastery_completions " +
+                            "DESC LIMIT " + Momentum.getSettingsManager().max_mastery_lb_size
+            );
+
+            for (Map<String, String> masteryCompletion : masteryCompletions) {
+                int completions = Integer.parseInt(masteryCompletion.get("total_mastery_completions"));
+                String playerName = masteryCompletion.get("name");
+
+                if (completions > 0) {
+                    masteryLB.add(new MasteryLBPosition(playerName, completions));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public ArrayList<CoinsLBPosition> getCoinsLB() {
         return coinsLB;
     }
 
     public ArrayList<ELOLBPosition> getELOLB() {
         return eloLB;
+    }
+
+    public ArrayList<MasteryLBPosition> getMasteryLB() {
+        return masteryLB;
     }
 
     public ELOLBPosition getELOLBPositionIfExists(String playerName) {

--- a/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
+++ b/src/main/java/com/renatusnetwork/momentum/data/stats/StatsManager.java
@@ -266,6 +266,11 @@ public class StatsManager {
         }
     }
 
+    // simply remove from offline cache without loading stats
+    public void removeOffline(String uuid) {
+        offlineCache.remove(uuid);
+    }
+
     public PlayerStats add(Player player) {
         // ensure thread safety
         synchronized (playerStatsUUID) {

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/Scoreboard.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/Scoreboard.java
@@ -266,56 +266,22 @@ public class Scoreboard {
                             String rewardString = Utils.translate("&6" + Utils.formatNumber(level.getReward()));
                             JackpotManager jackpotManager = Momentum.getJackpotManager();
 
-                            int newReward = level.getReward();
+                            int reward = Momentum.getLevelManager().calculateLevelRewardForPlayer(playerStats, level);
 
-                            // always modify level booster
-                            if (playerStats.hasModifier(ModifierType.LEVEL_BOOSTER)) {
-                                // downcast and boost
-                                Booster booster = (Booster) playerStats.getModifier(ModifierType.LEVEL_BOOSTER);
-                                newReward *= booster.getMultiplier();
-                            }
 
                             // if level has mastery and player is in mastery
                             if (level.hasMastery() && playerStats.isAttemptingMastery()) {
                                 board.add(formatSpacing(Utils.translate("&5&lMASTERY")));
-                                newReward *= level.getMasteryMultiplier();
-                            }
-                            // add title and adjust rewardstring if it is a featured level
-                            else if (level.isFeaturedLevel()) {
+                            } else if (level.isFeaturedLevel()) { // add title and adjust rewardstring if it is a featured level
                                 board.add(formatSpacing(Utils.translate("&c&lFEATURED")));
-                                newReward *= Momentum.getSettingsManager().featured_level_reward_multiplier;
                             } else if (jackpotManager.isJackpotRunning() &&
                                         jackpotManager.getJackpot().getLevelName().equalsIgnoreCase(level.getName()) &&
                                        !jackpotManager.getJackpot().hasCompleted(playerStats.getName())) {
-                                Jackpot jackpot = jackpotManager.getJackpot();
-                                int bonus = jackpot.getBonus();
-
-                                if (playerStats.hasModifier(ModifierType.JACKPOT_BOOSTER)) {
-                                    // downcast and boost
-                                    Booster booster = (Booster) playerStats.getModifier(ModifierType.JACKPOT_BOOSTER);
-                                    bonus *= booster.getMultiplier();
-                                }
-                                // add bonus multiplier
-                                newReward += bonus;
-
                                 board.add(formatSpacing(Utils.translate("&a&lJACKPOT")));
                             }
-                            // modifier section
-                            else {
-                                if (playerStats.hasPrestiges() && level.hasReward()) {
-                                    newReward *= playerStats.getPrestigeMultiplier();
-                                }
 
-                                LevelManager levelManager = Momentum.getLevelManager();
-
-                                // set cooldown modifier last!
-                                if (level.hasCooldown() && levelManager.inCooldownMap(playerStats.getName()) && levelManager.getLevelCooldown(playerStats.getName()).getModifier() != 1.00) {
-                                    newReward *= levelManager.getLevelCooldown(playerStats.getName()).getModifier();
-                                }
-                            }
-
-                            if (newReward != level.getReward()) {
-                                rewardString = Utils.translate("&c&m" + Utils.formatNumber(level.getReward()) + "&6 " + Utils.formatNumber(newReward));
+                            if (reward != level.getReward()) {
+                                rewardString = Utils.translate("&c&m" + Utils.formatNumber(level.getReward()) + "&6 " + Utils.formatNumber(reward));
                             }
 
                             board.add(formatSpacing(level.getFormattedTitle()));

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -82,56 +82,60 @@ public class InteractListener implements Listener {
                         if (!playerStats.isEventParticipant()) {
                             if (!playerStats.isSpectating()) {
                                 if (!playerStats.isPreviewingLevel()) {
-                                    if (level != null) {
-                                        if (level.getStartLocation() != null) {
-                                            // gets if they have right clicked it already, if so, cancel the task and reset them
-                                            if (!resetConfirmMap.containsKey(player.getName())) {
-                                                // otherwise, put them in and ask them to confirm within 5 seconds
-                                                player.sendMessage(Utils.translate("&cAre you sure you want to reset? Right click again to confirm"));
+                                    if (!playerStats.inPracticeMode()) {
+                                        if (level != null) {
+                                            if (level.getStartLocation() != null) {
+                                                // gets if they have right clicked it already, if so, cancel the task and reset them
+                                                if (!resetConfirmMap.containsKey(player.getName())) {
+                                                    // otherwise, put them in and ask them to confirm within 5 seconds
+                                                    player.sendMessage(Utils.translate("&cAre you sure you want to reset? Right click again to confirm"));
 
-                                                resetConfirmMap.put(player.getName(), new BukkitRunnable() {
-                                                    @Override
-                                                    public void run() {
-                                                        if (resetConfirmMap.containsKey(player.getName())) {
-                                                            resetConfirmMap.remove(player.getName());
-                                                            player.sendMessage(Utils.translate("&cYou did not confirm in time"));
+                                                    resetConfirmMap.put(player.getName(), new BukkitRunnable() {
+                                                        @Override
+                                                        public void run() {
+                                                            if (resetConfirmMap.containsKey(player.getName())) {
+                                                                resetConfirmMap.remove(player.getName());
+                                                                player.sendMessage(Utils.translate("&cYou did not confirm in time"));
+                                                            }
+                                                        }
+                                                    }.runTaskLater(Momentum.getPlugin(), 20 * 5));
+                                                } else {
+                                                    resetConfirmMap.get(player.getName()).cancel();
+
+                                                    Momentum.getCheckpointManager().deleteCheckpoint(playerStats, level);
+
+                                                    // statsManager.resetPracticeDataOnly(playerStats);
+                                                    playerStats.disableLevelStartTime();
+
+                                                    if (level.hasPotionEffects()) {
+
+                                                        playerStats.clearPotionEffects();
+
+                                                        // if has nv status, add nv
+                                                        if (playerStats.hasNightVision()) {
+                                                            player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
+                                                        }
+
+                                                        for (PotionEffect potionEffect : level.getPotionEffects()) {
+                                                            if (playerStats.hasNightVision() || potionEffect.getType() != PotionEffectType.NIGHT_VISION) {
+                                                                player.addPotionEffect(potionEffect);
+                                                            }
                                                         }
                                                     }
-                                                }.runTaskLater(Momentum.getPlugin(), 20 * 5));
-                                            } else {
-                                                resetConfirmMap.get(player.getName()).cancel();
+                                                    resetConfirmMap.remove(player.getName());
 
-                                                Momentum.getCheckpointManager().deleteCheckpoint(playerStats, level);
-
-                                                statsManager.resetPracticeDataOnly(playerStats);
-                                                playerStats.disableLevelStartTime();
-
-                                                if (level.hasPotionEffects()) {
-
-                                                    playerStats.clearPotionEffects();
-
-                                                    // if has nv status, add nv
-                                                    if (playerStats.hasNightVision()) {
-                                                        player.addPotionEffect(new PotionEffect(PotionEffectType.NIGHT_VISION, Integer.MAX_VALUE, 0));
-                                                    }
-
-                                                    for (PotionEffect potionEffect : level.getPotionEffects()) {
-                                                        if (playerStats.hasNightVision() || potionEffect.getType() != PotionEffectType.NIGHT_VISION) {
-                                                            player.addPotionEffect(potionEffect);
-                                                        }
-                                                    }
+                                                    playerStats.teleport(level.getStartLocation(), true);
+                                                    playerStats.resetFails();
+                                                    player.playSound(player.getLocation(), Sound.BLOCK_WOODEN_DOOR_CLOSE, 0.5f, 1f);
                                                 }
-                                                resetConfirmMap.remove(player.getName());
-
-                                                playerStats.teleport(level.getStartLocation(), true);
-                                                playerStats.resetFails();
-                                                player.playSound(player.getLocation(), Sound.BLOCK_WOODEN_DOOR_CLOSE, 0.5f, 1f);
+                                            } else {
+                                                player.sendMessage(Utils.translate("&cYou cannot reset a level with no start location"));
                                             }
                                         } else {
-                                            player.sendMessage(Utils.translate("&cYou cannot reset a level with no start location"));
+                                            player.sendMessage(Utils.translate("&cYou are not in a level"));
                                         }
                                     } else {
-                                        player.sendMessage(Utils.translate("&cYou are not in a level"));
+                                        player.sendMessage(Utils.translate("&cYou cannot do this while in /prac"));
                                     }
                                 } else {
                                     player.sendMessage(Utils.translate("&cYou cannot do this while previewing a level"));

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -219,7 +219,7 @@ public class InteractListener implements Listener {
                     csign.getCommands().forEach(cmd -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd.replaceAll("%player%", playerStats.getName())));
 
                     if (csign.isBroadcast()) {
-                        Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 claimed the sign &2" + csign.getTitle()));
+                        Bukkit.broadcastMessage(Utils.translate("&c" + player.getDisplayName() + "&7 has claimed &2" + (csign.getTitle() == null ? csign.getName() : csign.getTitle())));
                     } else {
                         player.sendMessage(Utils.translate("&aYou have claimed this sign"));
                     }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/InteractListener.java
@@ -186,6 +186,8 @@ public class InteractListener implements Listener {
 
                             playerStats.sendMessage(Utils.translate(forfeitMessage));
                             playerStats.endRace(playerStats.getRace().getOpponent(), RaceEndReason.FORFEIT);
+                        } else if (playerStats.isPreviewingLevel()) {
+                            playerStats.resetPreviewLevel();
                         } else {
                             Momentum.getLocationManager().teleportToSpawn(playerStats, player);
                         }

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/MenuListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/MenuListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -113,7 +114,7 @@ public class MenuListener implements Listener {
         menuManager.removeChoosingRating(name);
 
         // remove if present
-        raceManager.removeChoosingRaceLevel(name);
+        // raceManager.removeChoosingRaceLevel(name);
 
         new BukkitRunnable() {
             @Override
@@ -121,11 +122,19 @@ public class MenuListener implements Listener {
                 Inventory openedInventory = event.getInventory();
                 Inventory nextInventory = event.getPlayer().getOpenInventory().getTopInventory();
 
+                String closedInvName = openedInventory.getName().replaceFirst("\\b[Pp][Gg]\\d+\\b", "");
+                String currentInvName = nextInventory.getName().replaceFirst("\\b[Pp][Gg]\\d+\\b", "");
+
+                if (!closedInvName.equalsIgnoreCase(currentInvName)) {
+                    raceManager.removeChoosingRaceLevel(name);
+                }
+
                 if (!openedInventory.getName().equalsIgnoreCase(nextInventory.getName())) {
                     LevelManager levelManager = Momentum.getLevelManager();
 
                     // remove buying
                     levelManager.removeBuyingLevel(name);
+
 
                     // cancelled tasks
                     CancelTasks cancelTasks = menuManager.getCancelTasks(name);

--- a/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
+++ b/src/main/java/com/renatusnetwork/momentum/gameplay/listeners/PacketListener.java
@@ -215,6 +215,18 @@ public class PacketListener implements Listener {
                             }.runTask(Momentum.getPlugin());
                         }
                         // if their loc
+                    } else if (playerStats.isPreviewingLevel()) {
+                        LevelPreview levelPreview = playerStats.getPreviewLevel();
+
+                        new BukkitRunnable() {
+                            @Override
+                            public void run() {
+                                // only teleport if they go out of the area
+                                if (levelPreview.shouldTeleport(playerStats.getPlayer().getLocation())) {
+                                    levelPreview.teleport();
+                                }
+                            }
+                        }.runTask(Momentum.getPlugin());
                     } else if (!playerStats.inLevel()) {
                         if (locationManager.isNearPortal(playerX, playerY, playerZ, 1, PortalType.INFINITE)) {
                             infiniteManager.startPK(playerStats, playerStats.getInfiniteType(), true);
@@ -244,18 +256,6 @@ public class PacketListener implements Listener {
                                 }
                             }.runTask(Momentum.getPlugin());
                         }
-                    } else if (playerStats.isPreviewingLevel()) {
-                        LevelPreview levelPreview = playerStats.getPreviewLevel();
-
-                        new BukkitRunnable() {
-                            @Override
-                            public void run() {
-                                // only teleport if they go out of the area
-                                if (levelPreview.shouldTeleport(playerStats.getPlayer().getLocation())) {
-                                    levelPreview.teleport();
-                                }
-                            }
-                        }.runTask(Momentum.getPlugin());
                     } else {
                         Level level = playerStats.getLevel();
 

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
@@ -189,6 +189,7 @@ public class TablesDB {
                        "broadcast BIT DEFAULT 0, " +
                        "liquid_reset BIT DEFAULT 1, " +
                        "new BIT DEFAULT 0, " +
+                       "legacy BIT DEFAULT 0, " +
                        "has_mastery BIT DEFAULT 0, " +
                        "tc BIT DEFAULT 0, " +
                        // keys

--- a/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
+++ b/src/main/java/com/renatusnetwork/momentum/storage/mysql/TablesDB.java
@@ -189,7 +189,6 @@ public class TablesDB {
                        "broadcast BIT DEFAULT 0, " +
                        "liquid_reset BIT DEFAULT 1, " +
                        "new BIT DEFAULT 0, " +
-                       "legacy BIT DEFAULT 0, " +
                        "has_mastery BIT DEFAULT 0, " +
                        "tc BIT DEFAULT 0, " +
                        // keys

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -19,7 +19,6 @@ import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.slf4j.helpers.MessageFormatter;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -258,13 +257,8 @@ public class Utils {
         }
     }
 
-    public static String translate(String template, Object... params) {
-        if (template == null) {
-            return null;
-        }
-
-        String message = MessageFormatter.basicArrayFormat(template, params);
-        return ChatColor.translateAlternateColorCodes('&', message);
+    public static String translate(String msg) {
+        return msg != null ? ChatColor.translateAlternateColorCodes('&', msg) : null;
     }
 
     public static Color getColorFromString(String colorName) {

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.slf4j.helpers.MessageFormatter;
 
 import java.text.DecimalFormat;
 import java.util.*;
@@ -257,8 +258,13 @@ public class Utils {
         }
     }
 
-    public static String translate(String msg) {
-        return msg != null ? ChatColor.translateAlternateColorCodes('&', msg) : null;
+    public static String translate(String template, Object... params) {
+        if (template == null) {
+            return null;
+        }
+
+        String message = MessageFormatter.basicArrayFormat(template, params);
+        return ChatColor.translateAlternateColorCodes('&', message);
     }
 
     public static Color getColorFromString(String colorName) {

--- a/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
+++ b/src/main/java/com/renatusnetwork/momentum/utils/Utils.java
@@ -188,14 +188,14 @@ public class Utils {
         return getItemStackIfExists(inventory, settingsManager.prac_item);
     }
 
-    public static ItemStack getSpawnItemIfExists(Inventory inventory) {
+    public static ItemStack getLeaveItem(Inventory inventory) {
         SettingsManager settingsManager = Momentum.getSettingsManager();
         return getItemStackIfExists(inventory, settingsManager.leave_item);
     }
 
-    public static void removeSpawnItemIfExists(Player player) {
+    public static void removeLeaveItem(Player player) {
         PlayerInventory inventory = player.getInventory();
-        ItemStack itemStack = Utils.getSpawnItemIfExists(inventory);
+        ItemStack itemStack = Utils.getLeaveItem(inventory);
 
         // remove if not null
         if (itemStack != null) {

--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -281,6 +281,7 @@ leaderboard_max_size:
   top_rated: 10
   coins: 10
   records: 10
+  mastery: 10
   infinite:
     classic: 10
     sprint: 10

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -136,3 +136,5 @@ commands:
   squads:
     description: "Momentum squads command"
     aliases: [squad, sq, sqc]
+  reset:
+    description: "Momentum stats reset command"


### PR DESCRIPTION
**Changelog**:
- Added legacy command for levels
- Fixed player counts in levels
- Fixed TC level toggle message

There's definitely a better way to update player counts in levels by automatically decrementing and incrementing on setting the player's level or resetting it, but there're a lot of edge cases to consider regarding region checking, so I went with the simple solution of resetting all levels' player counts to 0 in light of time.